### PR TITLE
Fix scrollbars always showing.

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -1,12 +1,10 @@
 body {
   background: #f8f8f8;
   margin: 0;
-  height: 100vh;
-  width: 100vw;
   font-family: Arial, sans-serif;
 }
 
 #root {
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,7 +151,7 @@ export default function App(): JSX.Element {
         <ThemeProvider theme={theme}>
           <Box id='app' display='flex' flexDirection='column' style={{height: '100%'}}>
             <TopBar />
-            <Box display='flex' flexDirection='row' flexGrow={1} alignItems='stretch'>
+            <Box display='flex' flexDirection='row' flexGrow={1}>
               <Sidebar />
               <MainContent />
             </Box>

--- a/frontend/src/components/SimulationChart.tsx
+++ b/frontend/src/components/SimulationChart.tsx
@@ -74,6 +74,7 @@ export default function SimulationChart(): JSX.Element {
   useEffect(() => {
     // Create chart instance (is called when props.scenarios changes)
     const chart = am4core.create('chartdiv', am4charts.XYChart);
+
     // Set localization
     chart.language.locale = i18n.language === 'de' ? am4lang_de_DE : am4lang_en_US;
 
@@ -327,8 +328,7 @@ export default function SimulationChart(): JSX.Element {
       <Box
         id='chartdiv'
         sx={{
-          height: '100%',
-          width: '100%',
+          height: 'calc(100% - 4px)',
           margin: 0,
           padding: 0,
           backgroundColor: theme.palette.background.paper,

--- a/frontend/src/components/TopBar/index.tsx
+++ b/frontend/src/components/TopBar/index.tsx
@@ -15,7 +15,6 @@ export default function TopBar(): JSX.Element {
   return (
     <Grid
       sx={{
-        width: '100%',
         height: '56px',
         backgroundColor: theme.palette.background.default,
         borderBottom: `1px solid ${theme.palette.divider}`,


### PR DESCRIPTION
Fixes #130 

I tracked down the issue to be internal to amCharts. Somehow the chart takes up 4 more pixels than specified. This screws with the whole page layout, by creating a vertical scollbar, which reduces the horizontal space, which leads to creating a horizontal scollbar ...

The fix is to always give the chart 4 pixels less vertically.