### PR TITLE
Feature/show only integers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 
 ### Improvements
 - Added a label to the scenario start day.
+- All numbers on in the scenario overview now show as integers.
 
 ### Bug fixes
 

--- a/frontend/src/components/Scenario.tsx
+++ b/frontend/src/components/Scenario.tsx
@@ -45,7 +45,7 @@ export default function Scenario(): JSX.Element {
   const [simulationModelKey, setSimulationModelKey] = useState<string>('unset');
   const [compartmentValues, setCompartmentValues] = useState<Dictionary<number> | null>(null);
 
-  const {formatNumber} = NumberFormatter(i18n.language, 3, 8);
+  const {formatNumber} = NumberFormatter(i18n.language, 1, 0);
 
   const getCompartmentValue = (compartment: string): string => {
     if (compartmentValues && compartment in compartmentValues) {


### PR DESCRIPTION
### Description

The compartment values in the scenario overview now show as integers only.

#### Related Issues

Resolves #213 

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] I added the changes to the next release section of the [changelog](../docs/changelog.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../docs/changelog.md)