### PR TITLE
:beetle: Fix the initial translation of 'germany' in the search bar.

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -17,6 +17,8 @@
 
 ### Fehlerbehebungen
 
+- Ein Fehler wurde behoben, der beim ersten Laden der Seite den Text in der Suchleiste nicht übersetzt hatte.
+
 ---
 
 ## v0.2.0-alpha

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -17,6 +17,8 @@
 
 ### Bug fixes
 
+- An error was fixed, which prevented the text in the search bar to be translated on an initial site visit.
+
 ---
 
 ## v0.2.0-alpha

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense} from 'react';
+import React, {Suspense, useEffect} from 'react';
 import {Provider} from 'react-redux';
 
 import './App.scss';
@@ -11,6 +11,9 @@ import Box from '@mui/material/Box';
 import {ThemeProvider} from '@mui/material/styles';
 import Theme from './util/Theme';
 import {PersistGate} from 'redux-persist/integration/react';
+import {useAppDispatch, useAppSelector} from './store/hooks';
+import {selectDistrict} from './store/DataSelectionSlice';
+import {useTranslation} from 'react-i18next';
 
 /**
  * This is the root element of the React application. It divides the main screen area into the three main components.
@@ -22,6 +25,7 @@ export default function App(): JSX.Element {
       <Provider store={Store}>
         <ThemeProvider theme={Theme}>
           <PersistGate loading={null} persistor={Persistor}>
+            <Initializer />
             <Box id='app' display='flex' flexDirection='column' sx={{height: '100%', width: '100%'}}>
               <TopBar />
               <Box
@@ -43,4 +47,24 @@ export default function App(): JSX.Element {
       </Provider>
     </Suspense>
   );
+}
+
+/**
+ * This component serves to initialize state, that is required for the whole application and has no other responsible
+ * component.
+ */
+function Initializer() {
+  const {t} = useTranslation();
+  const selectedDistrict = useAppSelector((state) => state.dataSelection.district);
+  const dispatch = useAppDispatch();
+
+  // This effect ensures, that we get the correct translation for 'germany'. This is required, as the store initializes
+  // before the translations are available.
+  useEffect(() => {
+    if (selectedDistrict.ags === '00000' && selectedDistrict.name === '') {
+      dispatch(selectDistrict({ags: '00000', name: t('germany'), type: ''}));
+    }
+  }, [selectedDistrict, t, dispatch]);
+
+  return null;
 }

--- a/frontend/src/__tests__/components/Sidebar/SearchBar.test.tsx
+++ b/frontend/src/__tests__/components/Sidebar/SearchBar.test.tsx
@@ -42,9 +42,9 @@ describe('SearchBar', () => {
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
 
-    await screen.findByDisplayValue('germany');
+    await screen.findByDisplayValue('');
 
-    userEvent.click(screen.getByDisplayValue('germany'));
+    userEvent.click(screen.getByDisplayValue(''));
 
     await screen.findByText('A');
     await screen.findByText('Aichach-Friedberg (BEZ.LK)');
@@ -83,7 +83,7 @@ describe('SearchBar', () => {
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
 
-    userEvent.type(screen.getByDisplayValue('germany'), 'Aic{Enter}');
+    userEvent.type(screen.getByDisplayValue(''), 'Aic{Enter}');
 
     await screen.findByDisplayValue('Aichach-Friedberg (BEZ.LK)');
     expect(Store.getState().dataSelection.district).toStrictEqual({
@@ -104,7 +104,7 @@ describe('SearchBar', () => {
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
 
-    userEvent.type(screen.getByDisplayValue('germany'), '{ArrowDown}{Enter}');
+    userEvent.type(screen.getByDisplayValue(''), '{ArrowDown}{Enter}');
 
     await screen.findByDisplayValue('Test District (BEZ.Test Type)');
     expect(Store.getState().dataSelection.district).toStrictEqual({
@@ -116,6 +116,6 @@ describe('SearchBar', () => {
 
   afterEach(() => {
     cleanup();
-    Store.dispatch(selectDistrict({ags: '00000', name: i18n.t('germany'), type: ''}));
+    Store.dispatch(selectDistrict({ags: '00000', name: '', type: ''}));
   });
 });

--- a/frontend/src/__tests__/store/DataSelectionSlice.test.ts
+++ b/frontend/src/__tests__/store/DataSelectionSlice.test.ts
@@ -9,7 +9,7 @@ import reducer, {
 
 describe('DataSelectionSlice', () => {
   const initialState = {
-    district: {ags: '00000', name: 'germany', type: ''},
+    district: {ags: '00000', name: '', type: ''},
     date: null,
     scenario: null,
     compartment: null,

--- a/frontend/src/components/Sidebar/SearchBar.tsx
+++ b/frontend/src/components/Sidebar/SearchBar.tsx
@@ -63,7 +63,7 @@ export default function SearchBar(): JSX.Element {
       );
     // this init should only run once on first render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [t]);
 
   return (
     <Container>

--- a/frontend/src/store/DataSelectionSlice.ts
+++ b/frontend/src/store/DataSelectionSlice.ts
@@ -1,5 +1,4 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
-import i18n from '../util/i18n';
 import {dateToISOString, Dictionary} from '../util/util';
 import {GroupFilter} from 'types/group';
 
@@ -30,7 +29,7 @@ export interface DataSelection {
 }
 
 const initialState: DataSelection = {
-  district: {ags: '00000', name: i18n.t('germany'), type: ''},
+  district: {ags: '00000', name: '', type: ''},
   date: null,
   scenario: null,
   compartment: null,


### PR DESCRIPTION
### Description

When first loading the website the name of 'germany' in the search bar was not translated, because the default state of the store was initialized before translations were available. This PR fixes that.

### Design Decisions

A new component was added, that initializes state at the very top level. It now checks, if the translation for the district is missing.

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)