### PR TITLE
Rename and disable group filter button

### DIFF
--- a/frontend/public/locales/de/global.json5
+++ b/frontend/public/locales/de/global.json5
@@ -33,7 +33,7 @@
     more: 'Mehr Eigenschaften',
     activate: 'Scenario aktivieren',
     deactivate: 'Scenario deaktivieren',
-    'manage-groups': 'Gruppen',
+    'manage-groups': 'Filter',
     'simulation-start-day': 'Simulationsstart',
   },
   'group-filters': {

--- a/frontend/public/locales/en/global.json5
+++ b/frontend/public/locales/en/global.json5
@@ -42,7 +42,7 @@
     more: 'More properties',
     activate: 'Activate scenario',
     deactivate: 'Deactivate scenario',
-    'manage-groups': 'Groups',
+    'manage-groups': 'Filters',
     'simulation-start-day': 'Simulation start',
   },
   'group-filters': {

--- a/frontend/src/components/Scenario.tsx
+++ b/frontend/src/components/Scenario.tsx
@@ -374,6 +374,7 @@ export default function Scenario(): JSX.Element {
           </Button>
 
           <Button
+            disabled // disable filters for pilot study as there is no filterable data yet
             variant='outlined'
             color='primary'
             sx={{


### PR DESCRIPTION
### Description
It renames the group filter button label from "Groups"/"Gruppen" to "Filters"/"Filter".
It also disables the button as there is no filterable data in the public backend yet.

#### Related Issues
- #274 
- #266 

### Design Decisions
The button is diables and not hidden in order to tease the future functionalityto the user and to avoid any changes or shifts in layout.

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [x] ~~Unit and/or integration tests have been added~~
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] ~~I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed~~
- [x] ~~I attached performance measurements to prevent performance degradation~~
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)