### PR TITLE
Flexible start end times

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -25,6 +25,7 @@
 - Der ausgewählte Infektionszustand wird nun auch in den Szenariokarten farbig hervorgehoben.
 - Das DLR-Logo in der Tableiste wurde durch das ESID-Logo ersetzt.
 - Das LOKI-Logo verweist nun auf die LOKI-Pandemics Webseite, anstatt der DLR-Webseite.
+- Es ist jetzt möglich einen beliebigen Tag mit Daten auszuwählen.
 
 ### Fehlerbehebungen
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -25,7 +25,7 @@
 - The selected infection state is now also highlighted in the scenario cards.
 - The DLR logo in the tab bar was replaced with the ESID logo.
 - The LOKI logo now leads to the LOKI-Pandemics, instead of the DLR website.
-- It is now possible to set the date to any date containing data.
+- It is now possible to set the date to any day containing data.
 
 ### Bug fixes
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -25,6 +25,7 @@
 - The selected infection state is now also highlighted in the scenario cards.
 - The DLR logo in the tab bar was replaced with the ESID logo.
 - The LOKI logo now leads to the LOKI-Pandemics, instead of the DLR website.
+- It is now possible to set the date to any date containing data.
 
 ### Bug fixes
 

--- a/frontend/public/locales/de/global.json5
+++ b/frontend/public/locales/de/global.json5
@@ -35,7 +35,7 @@
     activate: 'Scenario aktivieren',
     deactivate: 'Scenario deaktivieren',
     'manage-groups': 'Filter',
-    'simulation-start-day': 'Simulationsstart',
+    'reference-day': 'Referenztag',
   },
   'group-filters': {
     title: 'Gruppen Verwalten',

--- a/frontend/public/locales/en/global.json5
+++ b/frontend/public/locales/en/global.json5
@@ -44,7 +44,7 @@
     activate: 'Activate scenario',
     deactivate: 'Deactivate scenario',
     'manage-groups': 'Filters',
-    'simulation-start-day': 'Simulation start',
+    'reference-day': 'Reference Day',
   },
   'group-filters': {
     title: 'Manage Groups',

--- a/frontend/src/components/Scenario/CompartmentList.tsx
+++ b/frontend/src/components/Scenario/CompartmentList.tsx
@@ -148,7 +148,7 @@ function SimulationStartTitle(): JSX.Element {
           fontSize: '13pt',
         }}
       >
-        {t('scenario.simulation-start-day')}:
+        {t('scenario.reference-day')}:
       </Typography>
       <Typography
         variant='h2'

--- a/frontend/src/components/Scenario/DataCard.tsx
+++ b/frontend/src/components/Scenario/DataCard.tsx
@@ -225,7 +225,7 @@ export function DataCard(props: DataCardProps): JSX.Element {
                   <CompartmentRow
                     key={compartment}
                     compartment={compartment}
-                    value={parseFloat(getCompartmentValue(compartment))}
+                    value={getCompartmentValue(compartment)}
                     rate={getCompartmentRate(compartment)}
                     color={props.color}
                     index={i}
@@ -287,7 +287,7 @@ interface CompartmentRowProps {
   compartment: string;
 
   /** The compartment value to display. */
-  value: number;
+  value: string;
 
   /** The rate of change to display. */
   rate: string;
@@ -348,7 +348,7 @@ function CompartmentRow(props: CompartmentRowProps): JSX.Element {
           flexBasis: '45%',
         }}
       />
-      <TrendArrow rate={props.rate} value={props.value} />
+      <TrendArrow rate={props.rate} value={parseFloat(props.value)} />
     </ListItem>
   );
 }

--- a/frontend/src/components/Scenario/DataCardList.tsx
+++ b/frontend/src/components/Scenario/DataCardList.tsx
@@ -84,17 +84,19 @@ export default function DataCardList(): JSX.Element {
     if (caseData?.data) {
       const entries = caseData.data.results.map((entry) => entry.day).sort((a, b) => a.localeCompare(b));
 
+      const firstCaseDataDay = entries[0];
       if (!minDate) {
-        minDate = entries[0];
+        minDate = firstCaseDataDay;
         dispatch(setStartDate(minDate));
       } else {
-        minDate = minDate.localeCompare(entries[0]) < 0 ? minDate : entries[0];
+        minDate = minDate.localeCompare(firstCaseDataDay) < 0 ? minDate : firstCaseDataDay;
       }
 
+      const lastCaseDataDay = entries.slice(-1)[0];
       if (!maxDate) {
-        maxDate = entries.slice(-1)[0];
+        maxDate = lastCaseDataDay;
       } else {
-        maxDate = maxDate.localeCompare(entries[0]) > 0 ? maxDate : entries.slice(-1)[0];
+        maxDate = maxDate.localeCompare(lastCaseDataDay) > 0 ? maxDate : lastCaseDataDay;
       }
     }
 

--- a/frontend/src/components/Scenario/DataCardList.tsx
+++ b/frontend/src/components/Scenario/DataCardList.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../store/services/scenarioApi';
 import {setCompartments, setScenarios} from '../../store/ScenarioSlice';
 import {useGetSimulationStartValues} from './hooks';
+import {useGetCaseDataByDistrictQuery} from '../../store/services/caseDataApi';
 
 export default function DataCardList(): JSX.Element {
   const theme = useTheme();
@@ -30,6 +31,9 @@ export default function DataCardList(): JSX.Element {
     skip: simulationModelKey === 'unset',
   });
 
+  // This is a temporary solution to get the start and end day of the case data.
+  const caseData = useGetCaseDataByDistrictQuery({node: '00000', groups: null, compartments: null});
+
   const startValues = useGetSimulationStartValues();
 
   useEffect(() => {
@@ -46,7 +50,11 @@ export default function DataCardList(): JSX.Element {
     }
   }, [simulationModelData, dispatch]);
 
+  // This effect calculates the start and end days from the case and scenario data.
   useEffect(() => {
+    let minDate: string | null = null;
+    let maxDate: string | null = null;
+
     if (scenarioListData) {
       const scenarios = scenarioListData.results.map((scenario) => ({id: scenario.id, label: scenario.description}));
       dispatch(setScenarios(scenarios));
@@ -66,11 +74,34 @@ export default function DataCardList(): JSX.Element {
         const endDay = new Date(startDay);
         endDay.setDate(endDay.getDate() + scenarioListData.results[0].numberOfDays - 1);
 
-        dispatch(setMinMaxDates({minDate: dateToISOString(startDay), maxDate: dateToISOString(endDay)}));
-        dispatch(setStartDate(scenarioListData.results[0].startDay));
+        minDate = dateToISOString(startDay);
+        maxDate = dateToISOString(endDay);
+
+        dispatch(setStartDate(minDate));
       }
     }
-  }, [activeScenarios, scenarioListData, dispatch]);
+
+    if (caseData?.data) {
+      const entries = caseData.data.results.map((entry) => entry.day).sort((a, b) => a.localeCompare(b));
+
+      if (!minDate) {
+        minDate = entries[0];
+        dispatch(setStartDate(minDate));
+      } else {
+        minDate = minDate.localeCompare(entries[0]) < 0 ? minDate : entries[0];
+      }
+
+      if (!maxDate) {
+        maxDate = entries.slice(-1)[0];
+      } else {
+        maxDate = maxDate.localeCompare(entries[0]) > 0 ? maxDate : entries.slice(-1)[0];
+      }
+    }
+
+    if (minDate && maxDate) {
+      dispatch(setMinMaxDates({minDate, maxDate}));
+    }
+  }, [activeScenarios, scenarioListData, dispatch, caseData]);
 
   //effect to switch active scenario
   useEffect(() => {

--- a/frontend/src/components/Scenario/hooks.ts
+++ b/frontend/src/components/Scenario/hooks.ts
@@ -4,7 +4,7 @@ import {useGetCaseDataSingleSimulationEntryQuery} from '../../store/services/cas
 import {useAppSelector} from '../../store/hooks';
 
 export function useGetSimulationStartValues() {
-  const startDay = useAppSelector((state) => state.dataSelection.minDate);
+  const startDay = useAppSelector((state) => state.dataSelection.simulationStart);
   const node = useAppSelector((state) => state.dataSelection.district.ags);
 
   const [compartmentValues, setCompartmentValues] = useState<Dictionary<number> | null>(null);

--- a/frontend/src/components/Sidebar/DistrictMap.tsx
+++ b/frontend/src/components/Sidebar/DistrictMap.tsx
@@ -81,9 +81,9 @@ export default function DistrictMap(): JSX.Element {
       return null;
     }
 
-    if (selectedScenario === 0 && caseData !== undefined) {
+    if (selectedScenario === 0 && caseData !== undefined && caseData.results.length > 0) {
       return caseData;
-    } else if (selectedScenario > 0 && simulationData !== undefined) {
+    } else if (selectedScenario > 0 && simulationData !== undefined && simulationData.results.length > 0) {
       return simulationData;
     }
 
@@ -253,7 +253,7 @@ export default function DistrictMap(): JSX.Element {
   useEffect(() => {
     if (chart && chart.series.length > 0) {
       const polygonSeries = chart.series.getIndex(0) as am5map.MapPolygonSeries;
-      if (selectedScenario !== null && selectedCompartment && !isFetching) {
+      if (selectedScenario !== null && selectedCompartment && !isFetching && data) {
         // Map compartment value to RS
         const dataMapped = new Map<string, number>();
         data?.results.forEach((entry) => {
@@ -289,18 +289,16 @@ export default function DistrictMap(): JSX.Element {
             });
           });
         }
-      } else {
-        if (longLoad) {
-          polygonSeries.mapPolygons.each((polygon) => {
-            const regionData = polygon.dataItem?.dataContext as IRegionPolygon;
-            regionData.value = Number.NaN;
-            const bez = t(`BEZ.${regionData.BEZ}`);
-            polygon.setAll({
-              tooltipText: `${bez} {GEN}`,
-              fill: am5.color(theme.palette.text.disabled),
-            });
+      } else if (longLoad || !data) {
+        polygonSeries.mapPolygons.each((polygon) => {
+          const regionData = polygon.dataItem?.dataContext as IRegionPolygon;
+          regionData.value = Number.NaN;
+          const bez = t(`BEZ.${regionData.BEZ}`);
+          polygon.setAll({
+            tooltipText: `${bez} {GEN}`,
+            fill: am5.color(theme.palette.text.disabled),
           });
-        }
+        });
       }
     }
   }, [

--- a/frontend/src/components/SimulationChart.tsx
+++ b/frontend/src/components/SimulationChart.tsx
@@ -43,6 +43,8 @@ export default function SimulationChart(): JSX.Element {
   const selectedDistrict = useAppSelector((state) => state.dataSelection.district.ags);
   const selectedCompartment = useAppSelector((state) => state.dataSelection.compartment);
   const selectedDate = useAppSelector((state) => state.dataSelection.date);
+  const minDate = useAppSelector((state) => state.dataSelection.minDate);
+  const maxDate = useAppSelector((state) => state.dataSelection.maxDate);
   const selectedScenario = useAppSelector((state) => state.dataSelection.scenario);
   const activeScenarios = useAppSelector((state) => state.dataSelection.activeScenarios);
   const groupFilterList = useAppSelector((state) => state.dataSelection.groupFilters);
@@ -208,6 +210,18 @@ export default function SimulationChart(): JSX.Element {
     // Re-run effect if language changes
     [i18n.language, t]
   );
+
+  // Effect to update min/max date.
+  useEffect(() => {
+    // Skip if root or chart is not initialized
+    if (!rootRef.current || !chartRef.current || !minDate || !maxDate) {
+      return;
+    }
+
+    const xAxis: DateAxis<AxisRendererX> = chartRef.current.xAxes.getIndex(0) as DateAxis<AxisRendererX>;
+    xAxis.set('min', new Date(minDate).setHours(0));
+    xAxis.set('max', new Date(maxDate).setHours(23, 59, 59));
+  }, [minDate, maxDate]);
 
   // Effect to add series to chart
   useEffect(

--- a/frontend/src/store/ScenarioSlice.ts
+++ b/frontend/src/store/ScenarioSlice.ts
@@ -31,7 +31,7 @@ export const ScenarioSlice = createSlice({
 export const {setScenarios, setCompartments} = ScenarioSlice.actions;
 export default ScenarioSlice.reducer;
 
-const preferredOrder = ['Infected', 'Hospitalized', 'ICU', 'Dead', 'Exposed', 'Recovered', 'Carrier', 'Susceptible'];
+const preferredOrder = ['InfectedV2', 'HospitalizedV2', 'ICUV2', 'Dead', 'ExposedV2', 'RecoveredV2', 'CarrierV2', 'Susceptible'];
 
 /** This function sorts an array with the first elements being the above preference if they are included in the array. */
 function sortWithPreference(array: Array<string>): Array<string> {

--- a/frontend/src/store/ScenarioSlice.ts
+++ b/frontend/src/store/ScenarioSlice.ts
@@ -31,7 +31,7 @@ export const ScenarioSlice = createSlice({
 export const {setScenarios, setCompartments} = ScenarioSlice.actions;
 export default ScenarioSlice.reducer;
 
-const preferredOrder = ['InfectedV2', 'HospitalizedV2', 'ICUV2', 'Dead', 'ExposedV2', 'RecoveredV2', 'CarrierV2', 'Susceptible'];
+const preferredOrder = ['Infected', 'Hospitalized', 'ICU', 'Dead', 'Exposed', 'Recovered', 'Carrier', 'Susceptible'];
 
 /** This function sorts an array with the first elements being the above preference if they are included in the array. */
 function sortWithPreference(array: Array<string>): Array<string> {


### PR DESCRIPTION
### Description

Previously the application required at least one scenario to be present, otherwise no start and end dates could be set. This now has been changed. The start and end dates are now the minimum and maximum of simulation and case data.

Additionally the "Simulation Start Date" has been renamed to "Reference Day". If a simulation is present it will represent the first day of the simulation, otherwise it will represent the first day, where case data is available.

#### Related Issues

Resolves #300

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [ ] ~~Unit and/or integration tests have been added~~
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [x] I attached performance measurements to prevent performance degradation
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] ~~I checked the added tests for completeness~~
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)