### PR TITLE
314 Correct initial compartments

### DIFF
--- a/backend/src/api/fixtures/initial_data.py
+++ b/backend/src/api/fixtures/initial_data.py
@@ -441,8 +441,8 @@ PARAMETERS = [
 
 COMPARTMENTS = [
     "MildInfections",
-    "Infected",
     "Hospitalized",
+    "ICU",
     "Dead"
 ]
 


### PR DESCRIPTION
### Description

When defining the compartments in backend/src/api/fixtures/initial_data.py for initializing the database we want to use ICU instead of Infected. This is corrected here.


#### Related Issues

Closes #314 


### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)