### PR TITLE
Add button to reset district map to initial view

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -17,6 +17,7 @@ SPDX-License-Identifier: CC-BY-4.0
   - Wenn diese Karte ausgewählt wird, werden die Falldaten dementsprechend im Rest der Anwendung angezeigt.
   - Es ist nun auch möglich die Falldaten alleine anzuzeigen, ohne dass ein Szenario aktiviert ist.
 - Neben der Liste der Infektionszustände ist jetzt zu jedem Infektionszustand ein Infokästchen. Aktuell haben alle Zustände die gleiche Information.
+- Die Zoom-Knöpfe der Karte haben eine weitere Schaltfläche bekommen, mit der die Kartenansicht zur ursprünglichen Übersicht zurückgesetzt werden kann.
 
 ### Verbesserungen
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -17,6 +17,7 @@ SPDX-License-Identifier: CC-BY-4.0
   - On selecting the card the case data will be displayed on the rest of the application correspondingly.
   - It is now also possible to view case data without any scenario activated.
 - Next to the list of infection states, there is now an info box for each infection state. Currently, all states have the same information.
+- The zoom control of the map now has an additional button to reset the view to the initial overview
 
 ### Improvements
 

--- a/frontend/src/components/Sidebar/DistrictMap.tsx
+++ b/frontend/src/components/Sidebar/DistrictMap.tsx
@@ -169,6 +169,8 @@ export default function DistrictMap(): JSX.Element {
         }),
       })
     );
+    // Add home button to reset pan & zoom
+    chart.get('zoomControl')?.homeButton.set('visible', true);
 
     // Create polygon series
     const polygonSeries = chart.series.push(


### PR DESCRIPTION
### Description
Adds a home button to the zoom controls in the district map to reset the pan and zoom level to the initial position.

#### Related Issues
- closes #98
- closes #172

### Checklist
**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)