### PR TITLE
Make deletion of scenarios possible 

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -162,7 +162,7 @@ class SimulationModel(models.Model):
 
 
 class ScenarioParameterGroup(models.Model):
-    distribution = models.ForeignKey(Distribution, related_name='distribution', on_delete=models.RESTRICT)
+    distribution = models.ForeignKey(Distribution, related_name='distribution', on_delete=models.CASCADE)
     groups = models.ManyToManyField(Group)
     
     @property
@@ -176,7 +176,7 @@ class ScenarioParameterGroup(models.Model):
 
 class ScenarioParameter(models.Model):
     """Model definition for a parameter belonging to a scenario."""
-    parameter = models.ForeignKey(Parameter, related_name='parameter', on_delete=models.RESTRICT)
+    parameter = models.ForeignKey(Parameter, related_name='parameter', on_delete=models.CASCADE)
     groups = models.ManyToManyField(ScenarioParameterGroup)
     
     class Meta:
@@ -190,7 +190,7 @@ class ScenarioNode(models.Model):
     """Model definition for a node belonging to a scenario (i.e. counties)."""
 
     # Fields
-    node = models.ForeignKey(Node, on_delete=models.RESTRICT)
+    node = models.ForeignKey(Node, on_delete=models.CASCADE)
     parameters = models.ManyToManyField(ScenarioParameter)
     interventions = models.ManyToManyField(Intervention)
 
@@ -219,7 +219,7 @@ class Scenario(models.Model):
     key = models.CharField(max_length=20, unique=True)
     name = models.CharField(max_length=100)
     description = models.TextField()
-    simulation_model = models.ForeignKey(SimulationModel, related_name='simulation_model', on_delete=models.RESTRICT)
+    simulation_model = models.ForeignKey(SimulationModel, related_name='simulation_model', on_delete=models.CASCADE)
     number_of_groups = models.IntegerField()
     number_of_nodes = models.IntegerField()
     nodes = models.ManyToManyField(ScenarioNode)
@@ -248,7 +248,7 @@ class Scenario(models.Model):
 
 class SimulationCompartment(Distribution):
     """Model definition for a compartment belonging to a simulation."""
-    compartment = models.ForeignKey(Compartment, on_delete=models.RESTRICT)
+    compartment = models.ForeignKey(Compartment, on_delete=models.CASCADE)
 
     class Meta:
         pass
@@ -260,7 +260,7 @@ class SimulationCompartment(Distribution):
 class SimulationNode(models.Model):
     """Model definition for a node belonging to a simulation (i.e. counties)."""
 
-    scenario_node = models.ForeignKey(ScenarioNode, on_delete=models.RESTRICT)
+    scenario_node = models.ForeignKey(ScenarioNode, on_delete=models.CASCADE)
     data = models.ManyToManyField(DataEntry)
 
     class Meta:
@@ -284,7 +284,7 @@ class Simulation(models.Model):
     start_day = models.DateField()
     number_of_days = models.IntegerField()
 
-    scenario = models.ForeignKey(Scenario, on_delete=models.RESTRICT)
+    scenario = models.ForeignKey(Scenario, on_delete=models.CASCADE)
     nodes = models.ManyToManyField(SimulationNode)
 
     class Meta:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

At the moment, we can't delete scenarios using the delete_scenario command. When changing `on_delete=models.RESTRICT` to `on_delete=models.CASCADE` this is possible. 


### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)