### PR TITLE
feature/parameter-units

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # ESID Änderungshistorie
 
-## vX.X.X-alpha
+## v0.3.0-beta
 
-**Veröffentlichungsdatum:** TBD
+**Veröffentlichungsdatum:** 03.05.2024
 
 ### Neue Funktionen
 
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 - Neben der Liste der Infektionszustände ist jetzt zu jedem Infektionszustand ein Infokästchen. Aktuell haben alle Zustände die gleiche Information.
 - Der Referenztag ist nun einstellbar. Eine Linie wird zum Graphen gezeichnet, um so den Zusammenhang zu verdeutlichen.
 - Die Zoom-Knöpfe der Karte haben ein neues Aussehen und eine weitere Schaltfläche bekommen, mit der die Kartenansicht zur ursprünglichen Übersicht über Deutschland zurückgesetzt werden kann.
+- Ein neuer Tab ist jetzt unter der Zeitserie zu finden, welcher die Parameter der Simulation anzeigt.
 
 ### Verbesserungen
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # ESID Changelog
 
-## vX.X.X-alpha
+## v0.3.0-beta
 
-**Release Date:** TBD
+**Release Date:** 03.05.2024
 
 ### New Features
 
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 - Next to the list of infection states, there is now an info box for each infection state. Currently, all states have the same information.
 - The reference day is now editable. A line is being drawn to the chart to show the connection.
 - The zoom controls of the map now have a new look and an additional button to reset the view to the initial overview of germany
+- A new tab is now available below the time series chart, which shows the simulation parameters.
 
 ### Improvements
 

--- a/frontend/locales/de-backend.json5
+++ b/frontend/locales/de-backend.json5
@@ -45,234 +45,234 @@
     AsymptoticCasesPerInfectious: {
       symbol: '\\mu_C^R',
       description: 'Anteil der nicht symptomatischen Fälle',
-      unit: '%'
+      unit: '%',
     },
     DeathsPerHospitalized: {
       symbol: '\\mu_U^D',
       description: 'Anteil der Personen, die auf der Intensivstation behandelt werden und sterben',
-      unit: '%'
+      unit: '%',
     },
     HomeToHospitalizedTime: {
       symbol: 'T_I',
       description: 'Mittlere Zeitspanne für Personen mit milden Symptomen',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     HospitalizedCasesPerInfectious: {
       symbol: '\\mu_I^H',
       description: 'Anteil der symptomatischen Fälle, die zu einem Krankenhausaufenthalt führen',
-      unit: '%'
+      unit: '%',
     },
     HospitalizedToHomeTime: {
       symbol: 'T_H',
       description: 'Dauer des notwendigen Krankenhausaufenthalts (ohne Intensivpflege)',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     HospitalizedToICUTime: {
       symbol: 'Veraltet',
       description: 'HospitalizedToICUTime',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     ICUCasesPerHospitalized: {
       symbol: '\\mu_H^U',
       description: 'Anteil der hospitalisierten Personen, welche später Intensivpflege benötigen',
-      unit: '%'
+      unit: '%',
     },
     ICUToDeathTime: {
       symbol: 'T_U',
       description: 'Dauer der notwendigen Intensivpflege',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     ICUToHomeTime: {
       symbol: 'Veraltet',
       description: 'ICUToHomeTime',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     InfectionProbabilityFromContact: {
       symbol: 'p^{(0)}',
       description: 'Grundlegendes Übertragungsrisiko (ohne Saisonalitätsfaktor)',
-      unit: '%'
+      unit: '%',
     },
     InfectiousTimeMild: {
       symbol: 'Veraltet',
       description: 'InfectiousTimeMild',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     MaxRiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximales relatives Infektionsrisiko durch nicht-isolierte symptomatische Individuen (mit Testkapazitätsbeschränkungen)',
-      unit: '%'
+      unit: '%',
     },
     ReducExpInf: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit partieller Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducImmuneExp: {
       symbol: 'p_{E_{II}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit hoher Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducImmuneExpInf: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit hoher Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducImmuneInfHosp: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektion für Personen mit hoher Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducInfHosp: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektionen für Personen mit partieller Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducTime: {
       symbol: '\\kappa',
       description: 'Relative Reduktion der Dauer milder Infektionen für partiell und gut geschützte Individuen',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     ReducVaccExp: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit partieller Immunität',
-      unit: '%'
+      unit: '%',
     },
     RelativeCarrierInfectability: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte nichtsymptomatische Individuen',
-      unit: '%'
+      unit: '%',
     },
     RiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte symptomatische Individuen',
-      unit: '%'
+      unit: '%',
     },
 
     // New Parameter Names
     RecoveredPerInfectedNoSymptoms: {
       symbol: '\\mu_C^R',
       description: 'Anteil der nicht symptomatischen Fälle',
-      unit: '%'
+      unit: '%',
     },
     DeathsPerCritical: {
       symbol: '\\mu_U^D',
       description: 'Anteil der Personen, die auf der Intensivstation behandelt werden und sterben',
-      unit: '%'
+      unit: '%',
     },
     TimeInfectedSymptoms: {
       symbol: 'T_I',
       description: 'Mittlere Zeitspanne für Personen mit milden Symptomen',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     SeverePerInfectedSymptoms: {
       symbol: '\\mu_I^H',
       description: 'Anteil der symptomatischen Fälle, die zu einem Krankenhausaufenthalt führen',
-      unit: '%'
+      unit: '%',
     },
     TimeInfectedSevere: {
       symbol: 'T_H',
       description: 'Dauer des notwendigen Krankenhausaufenthalts (ohne Intensivpflege)',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     CriticalPerSevere: {
       symbol: '\\mu_H^U',
       description: 'Anteil der hospitalisierten Personen, welche später Intensivpflege benötigen',
-      unit: '%'
+      unit: '%',
     },
     TimeInfectedCritical: {
       symbol: 'T_U',
       description: 'Dauer der notwendigen Intensivpflege',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     IncubationTime: {
       symbol: 'IT',
       description: 'Zeitraum des latenten nicht-infektiösen Stadiums',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     TransmissionProbabilityOnContact: {
       symbol: 'p^{(0)}',
       description: 'Grundlegendes Übertragungsrisiko (ohne Saisonalitätsfaktor)',
-      unit: '%'
+      unit: '%',
     },
     MaxRiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximales relatives Infektionsrisiko durch nicht-isolierte symptomatische Individuen (mit Testkapazitätsbeschränkungen)',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSymptomsPartialImmunity: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit partieller Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducExposedImprovedImmunity: {
       symbol: 'p_{E_{II}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit hoher Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSymptomsImprovedImmunity: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit hoher Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSevereCriticalDeadImprovedImmunity: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektion für Personen mit hoher Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSevereCriticalDeadPartialImmunity: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektionen für Personen mit partieller Immunität',
-      unit: '%'
+      unit: '%',
     },
     ReducTimeInfectedMild: {
       symbol: '\\kappa',
       description: 'Relative Reduktion der Dauer milder Infektionen für partiell und gut geschützte Individuen',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     ReducExposedPartialImmunity: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit partieller Immunität',
-      unit: '%'
+      unit: '%',
     },
     RelativeTransmissionNoSymptoms: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte nichtsymptomatische Individuen',
-      unit: '%'
+      unit: '%',
     },
     RiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte symptomatische Individuen',
-      unit: '%'
+      unit: '%',
     },
     Seasonality: {
       symbol: 'k',
       description: 'Anteil eines relativen Saisonalitätsfaktors',
-      unit: '%'
+      unit: '%',
     },
     SerialInterval: {
       symbol: 'SI',
       description: 'Serielles Intervall zwischen zwei aufeinanderfolgenden Infektionen',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     VaccinationGap: {
       symbol: '-',
       description: 'Zeit in Tagen zwischen erster und zweiter Impfung',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     ContactScaling: {
       symbol: '-',
       description: 'Skalierung der Kontakte, z.B. durch NPIs',
-      unit: '%'
+      unit: '%',
     },
     TimeExposed: {
       symbol: 'T_E',
       description: 'Mittlere Zeitspanne bevor angesteckte Personen infektiös werden',
-      unit: 'Tage'
+      unit: 'Tage',
     },
     TimeInfectedNoSymptoms: {
       symbol: 'T_C',
       description: 'Mittlere Zeitspanne der Infektiösität ohne Symptome',
-      unit: 'Tage'
+      unit: 'Tage',
     },
   },
   'scenario-names': {

--- a/frontend/locales/de-backend.json5
+++ b/frontend/locales/de-backend.json5
@@ -45,188 +45,234 @@
     AsymptoticCasesPerInfectious: {
       symbol: '\\mu_C^R',
       description: 'Anteil der nicht symptomatischen Fälle',
+      unit: '%'
     },
     DeathsPerHospitalized: {
       symbol: '\\mu_U^D',
       description: 'Anteil der Personen, die auf der Intensivstation behandelt werden und sterben',
+      unit: '%'
     },
     HomeToHospitalizedTime: {
       symbol: 'T_I',
       description: 'Mittlere Zeitspanne für Personen mit milden Symptomen',
+      unit: 'Tage'
     },
     HospitalizedCasesPerInfectious: {
       symbol: '\\mu_I^H',
       description: 'Anteil der symptomatischen Fälle, die zu einem Krankenhausaufenthalt führen',
+      unit: '%'
     },
     HospitalizedToHomeTime: {
       symbol: 'T_H',
       description: 'Dauer des notwendigen Krankenhausaufenthalts (ohne Intensivpflege)',
+      unit: 'Tage'
     },
     HospitalizedToICUTime: {
       symbol: 'Veraltet',
       description: 'HospitalizedToICUTime',
+      unit: 'Tage'
     },
     ICUCasesPerHospitalized: {
       symbol: '\\mu_H^U',
       description: 'Anteil der hospitalisierten Personen, welche später Intensivpflege benötigen',
+      unit: '%'
     },
     ICUToDeathTime: {
       symbol: 'T_U',
       description: 'Dauer der notwendigen Intensivpflege',
+      unit: 'Tage'
     },
     ICUToHomeTime: {
       symbol: 'Veraltet',
       description: 'ICUToHomeTime',
+      unit: 'Tage'
     },
     InfectionProbabilityFromContact: {
       symbol: 'p^{(0)}',
       description: 'Grundlegendes Übertragungsrisiko (ohne Saisonalitätsfaktor)',
+      unit: '%'
     },
     InfectiousTimeMild: {
       symbol: 'Veraltet',
       description: 'InfectiousTimeMild',
+      unit: 'Tage'
     },
     MaxRiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximales relatives Infektionsrisiko durch nicht-isolierte symptomatische Individuen (mit Testkapazitätsbeschränkungen)',
+      unit: '%'
     },
     ReducExpInf: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit partieller Immunität',
+      unit: '%'
     },
     ReducImmuneExp: {
       symbol: 'p_{E_{II}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit hoher Immunität',
+      unit: '%'
     },
     ReducImmuneExpInf: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit hoher Immunität',
+      unit: '%'
     },
     ReducImmuneInfHosp: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektion für Personen mit hoher Immunität',
+      unit: '%'
     },
     ReducInfHosp: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektionen für Personen mit partieller Immunität',
+      unit: '%'
     },
     ReducTime: {
       symbol: '\\kappa',
       description: 'Relative Reduktion der Dauer milder Infektionen für partiell und gut geschützte Individuen',
+      unit: 'Tage'
     },
     ReducVaccExp: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit partieller Immunität',
+      unit: '%'
     },
     RelativeCarrierInfectability: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte nichtsymptomatische Individuen',
+      unit: '%'
     },
     RiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte symptomatische Individuen',
+      unit: '%'
     },
 
     // New Parameter Names
     RecoveredPerInfectedNoSymptoms: {
       symbol: '\\mu_C^R',
       description: 'Anteil der nicht symptomatischen Fälle',
+      unit: '%'
     },
     DeathsPerCritical: {
       symbol: '\\mu_U^D',
       description: 'Anteil der Personen, die auf der Intensivstation behandelt werden und sterben',
+      unit: '%'
     },
     TimeInfectedSymptoms: {
       symbol: 'T_I',
       description: 'Mittlere Zeitspanne für Personen mit milden Symptomen',
+      unit: 'Tage'
     },
     SeverePerInfectedSymptoms: {
       symbol: '\\mu_I^H',
       description: 'Anteil der symptomatischen Fälle, die zu einem Krankenhausaufenthalt führen',
+      unit: '%'
     },
     TimeInfectedSevere: {
       symbol: 'T_H',
       description: 'Dauer des notwendigen Krankenhausaufenthalts (ohne Intensivpflege)',
+      unit: 'Tage'
     },
     CriticalPerSevere: {
       symbol: '\\mu_H^U',
       description: 'Anteil der hospitalisierten Personen, welche später Intensivpflege benötigen',
+      unit: '%'
     },
     TimeInfectedCritical: {
       symbol: 'T_U',
       description: 'Dauer der notwendigen Intensivpflege',
+      unit: 'Tage'
     },
     IncubationTime: {
       symbol: 'IT',
       description: 'Zeitraum des latenten nicht-infektiösen Stadiums',
+      unit: 'Tage'
     },
     TransmissionProbabilityOnContact: {
       symbol: 'p^{(0)}',
       description: 'Grundlegendes Übertragungsrisiko (ohne Saisonalitätsfaktor)',
+      unit: '%'
     },
     MaxRiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximales relatives Infektionsrisiko durch nicht-isolierte symptomatische Individuen (mit Testkapazitätsbeschränkungen)',
+      unit: '%'
     },
     ReducInfectedSymptomsPartialImmunity: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit partieller Immunität',
+      unit: '%'
     },
     ReducExposedImprovedImmunity: {
       symbol: 'p_{E_{II}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit hoher Immunität',
+      unit: '%'
     },
     ReducInfectedSymptomsImprovedImmunity: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative Reduktion symptomatischer Infektionen für Personen mit hoher Immunität',
+      unit: '%'
     },
     ReducInfectedSevereCriticalDeadImprovedImmunity: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektion für Personen mit hoher Immunität',
+      unit: '%'
     },
     ReducInfectedSevereCriticalDeadPartialImmunity: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative Reduktion schwerer oder kritischer Infektionen für Personen mit partieller Immunität',
+      unit: '%'
     },
     ReducTimeInfectedMild: {
       symbol: '\\kappa',
       description: 'Relative Reduktion der Dauer milder Infektionen für partiell und gut geschützte Individuen',
+      unit: 'Tage'
     },
     ReducExposedPartialImmunity: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative Reduktion jedweder Infektion für Personen mit partieller Immunität',
+      unit: '%'
     },
     RelativeTransmissionNoSymptoms: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte nichtsymptomatische Individuen',
+      unit: '%'
     },
     RiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relatives Infektionsrisiko durch nichtisolierte symptomatische Individuen',
+      unit: '%'
     },
     Seasonality: {
       symbol: 'k',
       description: 'Anteil eines relativen Saisonalitätsfaktors',
+      unit: '%'
     },
     SerialInterval: {
       symbol: 'SI',
       description: 'Serielles Intervall zwischen zwei aufeinanderfolgenden Infektionen',
+      unit: 'Tage'
     },
     VaccinationGap: {
       symbol: '-',
       description: 'Zeit in Tagen zwischen erster und zweiter Impfung',
+      unit: 'Tage'
     },
     ContactScaling: {
       symbol: '-',
       description: 'Skalierung der Kontakte, z.B. durch NPIs',
+      unit: '%'
     },
     TimeExposed: {
       symbol: 'T_E',
       description: 'Mittlere Zeitspanne bevor angesteckte Personen infektiös werden',
+      unit: 'Tage'
     },
     TimeInfectedNoSymptoms: {
       symbol: 'T_C',
       description: 'Mittlere Zeitspanne der Infektiösität ohne Symptome',
+      unit: 'Tage'
     },
   },
   'scenario-names': {

--- a/frontend/locales/en-backend.json5
+++ b/frontend/locales/en-backend.json5
@@ -44,233 +44,233 @@
     AsymptoticCasesPerInfectious: {
       symbol: '\\mu_C^R',
       description: 'Share of nonsymptomatic cases',
-      unit: '%'
+      unit: '%',
     },
     DeathsPerHospitalized: {
       symbol: '\\mu_U^D',
       description: 'Share of persons that die during ICU treatment',
-      unit: '%'
+      unit: '%',
     },
     HomeToHospitalizedTime: {
       symbol: 'T_I',
       description: 'Average time span for persons with mild symptoms',
-      unit: 'days'
+      unit: 'days',
     },
     HospitalizedCasesPerInfectious: {
       symbol: '\\mu_I^H',
       description: 'Share of symptomatic individuals that later need hospitalization',
-      unit: '%'
+      unit: '%',
     },
     HospitalizedToHomeTime: {
       symbol: 'T_H',
       description: 'Time span of necessary hospitalization (without ICU)',
-      unit: 'days'
+      unit: 'days',
     },
     HospitalizedToICUTime: {
       symbol: 'Deprecated',
       description: 'HospitalizedToICUTime',
-      unit: 'days'
+      unit: 'days',
     },
     ICUCasesPerHospitalized: {
       symbol: '\\mu_H^U',
       description: 'Share of hospitalized patients that later need ICU treatment',
-      unit: '%'
+      unit: '%',
     },
     ICUToDeathTime: {
       symbol: 'T_U',
       description: 'Time span of necessary ICU treatment',
-      unit: 'days'
+      unit: 'days',
     },
     ICUToHomeTime: {
       symbol: 'Deprecated',
       description: 'ICUToHomeTime',
-      unit: 'days'
+      unit: 'days',
     },
     InfectionProbabilityFromContact: {
       symbol: 'p^{(0)}',
       description: 'Basic Transmission risk (without seasonality factor)',
-      unit: '%'
+      unit: '%',
     },
     InfectiousTimeMild: {
       symbol: 'Deprecated',
       description: 'InfectiousTimeMild',
-      unit: 'days'
+      unit: 'days',
     },
     MaxRiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximum relative risk of infection from nonisolated symptomatic individuals (with test capacity limitations)',
-      unit: '%'
+      unit: '%',
     },
     ReducExpInf: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative reduction against symptomatic CODs for individuals with partial immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducImmuneExp: {
       symbol: 'p_{E_{II}}',
       description: 'Relative reduction against any infection for individuals with improved immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducImmuneExpInf: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative reduction against symptomatic CODs for individuals with improved immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducImmuneInfHosp: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative reduction against severe and critical CODs for individuals with improved immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducInfHosp: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative reduction against severe and critical CODs for individuals with partial immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducTime: {
       symbol: '\\kappa',
       description: 'Relative reduction of time span of mild infections for individuals with partial and improved immunity',
-      unit: 'days'
+      unit: 'days',
     },
     ReducVaccExp: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative reduction against any infection for individuals with partial immunity',
-      unit: '%'
+      unit: '%',
     },
     RelativeCarrierInfectability: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relative risk of infection from nonisolated nonsymptomatic individuals',
-      unit: '%'
+      unit: '%',
     },
     RiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relative risk of infection from nonisolated symptomatic individuals',
-      unit: '%'
+      unit: '%',
     },
     // New Parameter Names
     RecoveredPerInfectedNoSymptoms: {
       symbol: '\\mu_C^R',
       description: 'Share of nonsymptomatic cases',
-      unit: '%'
+      unit: '%',
     },
     DeathsPerCritical: {
       symbol: '\\mu_U^D',
       description: 'Share of persons that die during ICU treatment',
-      unit: '%'
+      unit: '%',
     },
     TimeInfectedSymptoms: {
       symbol: 'T_I',
       description: 'Average time span for persons with mild symptoms',
-      unit: 'days'
+      unit: 'days',
     },
     SeverePerInfectedSymptoms: {
       symbol: '\\mu_I^H',
       description: 'Share of symptomatic individuals that later need hospitalization',
-      unit: '%'
+      unit: '%',
     },
     TimeInfectedSevere: {
       symbol: 'T_H',
       description: 'Time span of necessary hospitalization (without ICU)',
-      unit: 'days'
+      unit: 'days',
     },
     CriticalPerSevere: {
       symbol: '\\mu_H^U',
       description: 'Share of hospitalized patients that later need ICU treatment',
-      unit: '%'
+      unit: '%',
     },
     TimeInfectedCritical: {
       symbol: 'T_U',
       description: 'Time span of necessary ICU treatment',
-      unit: 'days'
+      unit: 'days',
     },
     IncubationTime: {
       symbol: 'IT',
       description: 'Incubation period',
-      unit: 'days'
+      unit: 'days',
     },
     TransmissionProbabilityOnContact: {
       symbol: 'p^{(0)}',
       description: 'Basic Transmission risk (without seasonality factor)',
-      unit: '%'
+      unit: '%',
     },
     MaxRiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximum relative risk of infection from nonisolated symptomatic individuals (with test capacity limitations)',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSymptomsPartialImmunity: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative reduction against symptomatic CODs for individuals with partial immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducExposedImprovedImmunity: {
       symbol: 'p_{E_{II}}',
       description: 'Relative reduction against any infection for individuals with improved immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSymptomsImprovedImmunity: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative reduction against symptomatic CODs for individuals with improved immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSevereCriticalDeadImprovedImmunity: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative reduction against severe and critical CODs for individuals with improved immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducInfectedSevereCriticalDeadPartialImmunity: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative reduction against severe and critical CODs for individuals with partial immunity',
-      unit: '%'
+      unit: '%',
     },
     ReducTimeInfectedMild: {
       symbol: '\\kappa',
       description: 'Relative reduction of time span of mild infections for individuals with partial and improved immunity',
-      unit: 'days'
+      unit: 'days',
     },
     ReducExposedPartialImmunity: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative reduction against any infection for individuals with partial immunity',
-      unit: '%'
+      unit: '%',
     },
     RelativeTransmissionNoSymptoms: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relative risk of infection from nonisolated nonsymptomatic individuals',
-      unit: '%'
+      unit: '%',
     },
     RiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relative risk of infection from nonisolated symptomatic individuals',
-      unit: '%'
+      unit: '%',
     },
     Seasonality: {
       symbol: 'k',
       description: 'Contribution of relative seasonal factor',
-      unit: '%'
+      unit: '%',
     },
     SerialInterval: {
       symbol: 'SI',
       description: 'Serial interval between two consecutive infections',
-      unit: 'days'
+      unit: 'days',
     },
     VaccinationGap: {
       symbol: '-',
       description: 'Time in days between first and second vaccine shot',
-      unit: 'days'
+      unit: 'days',
     },
     ContactScaling: {
       symbol: '-',
       description: 'Scaling of contacts due to e.g. NPIs',
-      unit: '%'
+      unit: '%',
     },
     TimeExposed: {
       symbol: 'T_E',
       description: 'Average time span before exposed individuals become infectious',
-      unit: 'days'
+      unit: 'days',
     },
     TimeInfectedNoSymptoms: {
       symbol: 'T_C',
       description: 'Average time span of infectiousness without symptoms',
-      unit: 'days'
+      unit: 'days',
     },
   },
   'scenario-names': {

--- a/frontend/locales/en-backend.json5
+++ b/frontend/locales/en-backend.json5
@@ -44,188 +44,233 @@
     AsymptoticCasesPerInfectious: {
       symbol: '\\mu_C^R',
       description: 'Share of nonsymptomatic cases',
+      unit: '%'
     },
     DeathsPerHospitalized: {
       symbol: '\\mu_U^D',
       description: 'Share of persons that die during ICU treatment',
+      unit: '%'
     },
     HomeToHospitalizedTime: {
       symbol: 'T_I',
       description: 'Average time span for persons with mild symptoms',
+      unit: 'days'
     },
     HospitalizedCasesPerInfectious: {
       symbol: '\\mu_I^H',
       description: 'Share of symptomatic individuals that later need hospitalization',
+      unit: '%'
     },
     HospitalizedToHomeTime: {
       symbol: 'T_H',
       description: 'Time span of necessary hospitalization (without ICU)',
+      unit: 'days'
     },
     HospitalizedToICUTime: {
       symbol: 'Deprecated',
       description: 'HospitalizedToICUTime',
+      unit: 'days'
     },
     ICUCasesPerHospitalized: {
       symbol: '\\mu_H^U',
       description: 'Share of hospitalized patients that later need ICU treatment',
+      unit: '%'
     },
     ICUToDeathTime: {
       symbol: 'T_U',
       description: 'Time span of necessary ICU treatment',
+      unit: 'days'
     },
     ICUToHomeTime: {
       symbol: 'Deprecated',
       description: 'ICUToHomeTime',
+      unit: 'days'
     },
     InfectionProbabilityFromContact: {
       symbol: 'p^{(0)}',
       description: 'Basic Transmission risk (without seasonality factor)',
+      unit: '%'
     },
     InfectiousTimeMild: {
       symbol: 'Deprecated',
       description: 'InfectiousTimeMild',
+      unit: 'days'
     },
     MaxRiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximum relative risk of infection from nonisolated symptomatic individuals (with test capacity limitations)',
+      unit: '%'
     },
     ReducExpInf: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative reduction against symptomatic CODs for individuals with partial immunity',
+      unit: '%'
     },
     ReducImmuneExp: {
       symbol: 'p_{E_{II}}',
       description: 'Relative reduction against any infection for individuals with improved immunity',
+      unit: '%'
     },
     ReducImmuneExpInf: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative reduction against symptomatic CODs for individuals with improved immunity',
+      unit: '%'
     },
     ReducImmuneInfHosp: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative reduction against severe and critical CODs for individuals with improved immunity',
+      unit: '%'
     },
     ReducInfHosp: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative reduction against severe and critical CODs for individuals with partial immunity',
+      unit: '%'
     },
     ReducTime: {
       symbol: '\\kappa',
       description: 'Relative reduction of time span of mild infections for individuals with partial and improved immunity',
+      unit: 'days'
     },
     ReducVaccExp: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative reduction against any infection for individuals with partial immunity',
+      unit: '%'
     },
     RelativeCarrierInfectability: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relative risk of infection from nonisolated nonsymptomatic individuals',
+      unit: '%'
     },
     RiskOfInfectionFromSympomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relative risk of infection from nonisolated symptomatic individuals',
+      unit: '%'
     },
-
     // New Parameter Names
     RecoveredPerInfectedNoSymptoms: {
       symbol: '\\mu_C^R',
       description: 'Share of nonsymptomatic cases',
+      unit: '%'
     },
     DeathsPerCritical: {
       symbol: '\\mu_U^D',
       description: 'Share of persons that die during ICU treatment',
+      unit: '%'
     },
     TimeInfectedSymptoms: {
       symbol: 'T_I',
       description: 'Average time span for persons with mild symptoms',
+      unit: 'days'
     },
     SeverePerInfectedSymptoms: {
       symbol: '\\mu_I^H',
       description: 'Share of symptomatic individuals that later need hospitalization',
+      unit: '%'
     },
     TimeInfectedSevere: {
       symbol: 'T_H',
       description: 'Time span of necessary hospitalization (without ICU)',
+      unit: 'days'
     },
     CriticalPerSevere: {
       symbol: '\\mu_H^U',
       description: 'Share of hospitalized patients that later need ICU treatment',
+      unit: '%'
     },
     TimeInfectedCritical: {
       symbol: 'T_U',
       description: 'Time span of necessary ICU treatment',
+      unit: 'days'
     },
     IncubationTime: {
       symbol: 'IT',
       description: 'Incubation period',
+      unit: 'days'
     },
     TransmissionProbabilityOnContact: {
       symbol: 'p^{(0)}',
       description: 'Basic Transmission risk (without seasonality factor)',
+      unit: '%'
     },
     MaxRiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy}}',
       description: 'Maximum relative risk of infection from nonisolated symptomatic individuals (with test capacity limitations)',
+      unit: '%'
     },
     ReducInfectedSymptomsPartialImmunity: {
       symbol: 'p_{I_{Sy,PI}}',
       description: 'Relative reduction against symptomatic CODs for individuals with partial immunity',
+      unit: '%'
     },
     ReducExposedImprovedImmunity: {
       symbol: 'p_{E_{II}}',
       description: 'Relative reduction against any infection for individuals with improved immunity',
+      unit: '%'
     },
     ReducInfectedSymptomsImprovedImmunity: {
       symbol: 'p_{I_{Sy,II}}',
       description: 'Relative reduction against symptomatic CODs for individuals with improved immunity',
+      unit: '%'
     },
     ReducInfectedSevereCriticalDeadImprovedImmunity: {
       symbol: 'p_{I_{Sev,II}}',
       description: 'Relative reduction against severe and critical CODs for individuals with improved immunity',
+      unit: '%'
     },
     ReducInfectedSevereCriticalDeadPartialImmunity: {
       symbol: 'p_{I_{Sev,PI}}',
       description: 'Relative reduction against severe and critical CODs for individuals with partial immunity',
+      unit: '%'
     },
     ReducTimeInfectedMild: {
       symbol: '\\kappa',
       description: 'Relative reduction of time span of mild infections for individuals with partial and improved immunity',
+      unit: 'days'
     },
     ReducExposedPartialImmunity: {
       symbol: 'p_{E_{PI}}',
       description: 'Relative reduction against any infection for individuals with partial immunity',
+      unit: '%'
     },
     RelativeTransmissionNoSymptoms: {
       symbol: '\\xi_{I_{NS}}',
       description: 'Relative risk of infection from nonisolated nonsymptomatic individuals',
+      unit: '%'
     },
     RiskOfInfectionFromSymptomatic: {
       symbol: '\\xi_{I_{Sy},max}',
       description: 'Relative risk of infection from nonisolated symptomatic individuals',
+      unit: '%'
     },
     Seasonality: {
       symbol: 'k',
       description: 'Contribution of relative seasonal factor',
+      unit: '%'
     },
     SerialInterval: {
       symbol: 'SI',
       description: 'Serial interval between two consecutive infections',
+      unit: 'days'
     },
     VaccinationGap: {
       symbol: '-',
       description: 'Time in days between first and second vaccine shot',
+      unit: 'days'
     },
     ContactScaling: {
       symbol: '-',
       description: 'Scaling of contacts due to e.g. NPIs',
+      unit: '%'
     },
     TimeExposed: {
       symbol: 'T_E',
       description: 'Average time span before exposed individuals become infectious',
+      unit: 'days'
     },
     TimeInfectedNoSymptoms: {
       symbol: 'T_C',
       description: 'Average time span of infectiousness without symptoms',
+      unit: 'days'
     },
   },
   'scenario-names': {

--- a/frontend/src/__tests__/components/ParameterEditor.test.tsx
+++ b/frontend/src/__tests__/components/ParameterEditor.test.tsx
@@ -31,7 +31,7 @@ describe('ParameterEditor', () => {
 
     await screen.findByText('parameters.Test Parameter 1.symbol');
     await screen.findByText('parameters.Test Parameter 1.description');
-    await screen.findByText('0 - 1');
+    await screen.findByText(/0 - 1 parameters\.Test Parameter 1\.unit/);
 
     await screen.findByText('parameters.Test Parameter 2.symbol');
     await screen.findByText('parameters.Test Parameter 2.description');


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

Adds units to the parameter view and sets a new ESID release in the changelog.


### Design Decisions

This hardcodes the units in the translation file. There is also logic to transform numbers with percent to be shown as percentages instead of normalized.

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [ ] ~~Unit and/or integration tests have been added~~
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] ~~I attached performance measurements to prevent performance degradation~~
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)