### PR TITLE
Fix heatlegend select

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Fehlerbehebungen
 
 - Fehlende Übersetzungen wurden ergänzt.
+- Die Auswahl der Farblegenden zeigt jetzt wieder eine Vorschau für alle Optionen.
 
 ---
 

--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -5,6 +5,20 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # ESID Änderungshistorie
 
+## v0.3.1-beta
+
+**Veröffentlichungsdatum:** TBD
+
+### Neue Funktionen
+
+### Verbesserungen
+
+### Fehlerbehebungen
+
+- Fehlende Übersetzungen wurden ergänzt.
+
+---
+
 ## v0.3.0-beta
 
 **Veröffentlichungsdatum:** 03.05.2024

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -16,6 +16,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Bug fixes
 
 - Missing translations were fixed.
+- The heat legend selection now shows a preview for all legends again.
 
 ---
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -5,6 +5,20 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # ESID Changelog
 
+## v0.3.1-beta
+
+**Release Date:** TBD
+
+### New Features
+
+### Improvements
+
+### Bug fixes
+
+- Missing translations were fixed.
+
+---
+
 ## v0.3.0-beta
 
 **Release Date:** 03.05.2024

--- a/frontend/locales/de-global.json5
+++ b/frontend/locales/de-global.json5
@@ -52,6 +52,7 @@
     'confirm-discard-title': 'Änderungen Verwerfen',
     'confirm-discard-text': 'Sie haben ungespeicherte Änderungen. Wollen sie diese verwerfen?',
     discard: 'Verwerfen',
+    delete: 'Löschen',
   },
   chart: {
     caseData: 'Geschätzte Fälle',

--- a/frontend/locales/en-global.json5
+++ b/frontend/locales/en-global.json5
@@ -61,6 +61,7 @@
     'confirm-discard-title': 'Discard Changes',
     'confirm-discard-text': 'You have unsaved changes. Do you want to discard them?',
     discard: 'Discard',
+    delete: 'Delete',
   },
   chart: {
     caseData: 'Estimated Cases',

--- a/frontend/src/components/ManageGroupDialog.tsx
+++ b/frontend/src/components/ManageGroupDialog.tsx
@@ -280,6 +280,8 @@ function GroupFilterCard(props: GroupFilterCardProps) {
           open={confirmDialogOpen}
           title={t('group-filters.confirm-deletion-title')}
           text={t('group-filters.confirm-deletion-text', {groupName: props.item.name})}
+          abortButtonText={t('group-filters.close')}
+          confirmButtonText={t('group-filters.delete')}
           onAnswer={(answer) => {
             if (answer) {
               dispatch(deleteGroupFilter(props.item.id));

--- a/frontend/src/components/Sidebar/HeatLegend.tsx
+++ b/frontend/src/components/Sidebar/HeatLegend.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
 // SPDX-License-Identifier: Apache-2.0
 
-import React, {useEffect} from 'react';
+import React, {useLayoutEffect} from 'react';
 import {useTheme} from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import * as am5 from '@amcharts/amcharts5';
@@ -9,21 +9,23 @@ import {useTranslation} from 'react-i18next';
 import {NumberFormatter} from 'util/hooks';
 import {HeatmapLegend} from '../../types/heatmapLegend';
 
-export default function HeatLegend(props: {
-  // add is_dynamic/absolute?
-  legend: HeatmapLegend;
-  exposeLegend: (legend: am5.HeatLegend | null) => void;
-  min: number;
-  max: number;
-  displayText: boolean;
-  id: string;
-}): JSX.Element {
+export default function HeatLegend(
+  props: Readonly<{
+    // add is_dynamic/absolute?
+    legend: HeatmapLegend;
+    exposeLegend: (legend: am5.HeatLegend | null) => void;
+    min: number;
+    max: number;
+    displayText: boolean;
+    id: string;
+  }>
+): JSX.Element {
   const id = props.id + String(Date.now() + Math.random()); // "guarantee" unique id
   const {i18n} = useTranslation();
   const {formatNumber} = NumberFormatter(i18n.language, 3, 8);
   const theme = useTheme();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const root = am5.Root.new(id);
     const heatLegend = root.container.children.push(
       am5.HeatLegend.new(root, {

--- a/frontend/src/components/Sidebar/HeatLegendEdit.tsx
+++ b/frontend/src/components/Sidebar/HeatLegendEdit.tsx
@@ -143,16 +143,6 @@ export default function HeatLegendEdit(): JSX.Element {
               {availablePresets.map((preset, i) => (
                 <MenuItem key={'legendPresetSelect' + i.toString()} value={preset.name}>
                   <Box sx={{width: '100%'}}>
-                    {/*<HeatLegend*/}
-                    {/*  legend={preset}*/}
-                    {/*  exposeLegend={() => {*/}
-                    {/*    return;*/}
-                    {/*  }}*/}
-                    {/*  min={0}*/}
-                    {/*  max={preset.steps[preset.steps.length - 1].value}*/}
-                    {/*  displayText={!preset.isNormalized}*/}
-                    {/*  id={preset.name}*/}
-                    {/*/>*/}
                     <LegendGradient legend={preset} />
                     <Box>
                       <Typography variant='h2' align='center'>

--- a/frontend/src/components/Sidebar/HeatLegendEdit.tsx
+++ b/frontend/src/components/Sidebar/HeatLegendEdit.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
 // SPDX-License-Identifier: Apache-2.0
 
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {useTheme} from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -13,7 +13,6 @@ import MenuItem from '@mui/material/MenuItem';
 import Select, {SelectChangeEvent} from '@mui/material/Select';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import HeatLegend from './HeatLegend';
 import EditIcon from '@mui/icons-material/Edit';
 import {useAppDispatch, useAppSelector} from '../../store/hooks';
 import {selectHeatmapLegend} from '../../store/UserPreferenceSlice';
@@ -143,25 +142,24 @@ export default function HeatLegendEdit(): JSX.Element {
             <Select id='heatmap-select' aria-label={t('heatlegend.select')} value={legend.name} onChange={handleChange}>
               {availablePresets.map((preset, i) => (
                 <MenuItem key={'legendPresetSelect' + i.toString()} value={preset.name}>
-                  <Grid container maxWidth='lg'>
-                    <Grid item xs={12}>
-                      <HeatLegend
-                        legend={preset}
-                        exposeLegend={() => {
-                          return;
-                        }}
-                        min={0}
-                        max={preset.steps[preset.steps.length - 1].value}
-                        displayText={!preset.isNormalized}
-                        id={preset.name}
-                      />
-                    </Grid>
-                    <Grid item xs={12}>
+                  <Box sx={{width: '100%'}}>
+                    {/*<HeatLegend*/}
+                    {/*  legend={preset}*/}
+                    {/*  exposeLegend={() => {*/}
+                    {/*    return;*/}
+                    {/*  }}*/}
+                    {/*  min={0}*/}
+                    {/*  max={preset.steps[preset.steps.length - 1].value}*/}
+                    {/*  displayText={!preset.isNormalized}*/}
+                    {/*  id={preset.name}*/}
+                    {/*/>*/}
+                    <LegendGradient legend={preset} />
+                    <Box>
                       <Typography variant='h2' align='center'>
                         {preset.name}
                       </Typography>
-                    </Grid>
-                  </Grid>
+                    </Box>
+                  </Box>
                 </MenuItem>
               ))}
             </Select>
@@ -174,6 +172,32 @@ export default function HeatLegendEdit(): JSX.Element {
         </Box>
       </Dialog>
     </>
+  );
+}
+
+function LegendGradient(props: Readonly<{legend: HeatmapLegend}>): JSX.Element {
+  const divRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!divRef.current) {
+      return;
+    }
+
+    const gradient = props.legend.steps
+      .map(({color, value}) => {
+        return `${color} ${Math.round(value * 100)}%`;
+      })
+      .join(', ');
+
+    divRef.current.style.background = `linear-gradient(90deg, ${gradient})`;
+  }, [props.legend]);
+
+  return (
+    <div
+      ref={divRef}
+      id={`legend-gradient-${props.legend.name}`}
+      style={{width: '100%', height: '50px', margin: '5px'}}
+    />
   );
 }
 


### PR DESCRIPTION
### Description

This PR fixes the previews of heatlegends in the heat legend select dialog.

#### Related Issues

Fixes #326 

### Design Decisions

Instead of using amCharts to render the heat legends we use a simple CSS gradient.

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] ~~Unit and/or integration tests have been added~~
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] ~~I attached performance measurements to prevent performance degradation~~
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)