### PR TITLE
Fix wrong or no Parameters for a Scenario

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -13,10 +13,13 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Verbesserungen
 
+- Es wurde mehr Übersetzungen für Szenarien hinzugefügt.
+
 ### Fehlerbehebungen
 
 - Fehlende Übersetzungen wurden ergänzt.
 - Die Auswahl der Farblegenden zeigt jetzt wieder eine Vorschau für alle Optionen.
+- Die Parameter werden jetzt korrekt dem ausgewählten Szenario zugeordnet und eine Info wird angezeigt, wenn keine Parameter verfügbar sind.
 
 ---
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -13,10 +13,13 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ### Improvements
 
+- Added translations for additional scenarios.
+
 ### Bug fixes
 
 - Missing translations were fixed.
 - The heat legend selection now shows a preview for all legends again.
+- The Parameters will now correctly be associated with the selected scenario and an info will be displayed, when no parameters are available.
 
 ---
 

--- a/frontend/locales/de-backend.json5
+++ b/frontend/locales/de-backend.json5
@@ -277,9 +277,9 @@
   },
   'scenario-names': {
     'Baseline Scenario': 'Basisszenario',
-    'baseline': 'Basisszenario',
-    'closed_schools': 'Geschlossene Schulen',
-    'remote_work': 'Homeoffice',
+    baseline: 'Basisszenario',
+    closed_schools: 'Geschlossene Schulen',
+    remote_work: 'Homeoffice',
     '10p_reduced_contacts ': '10% Kontaktreduzierung',
     'Summer 2021 Simulation 1': 'Szenario ohne Maßnahmen',
     'Summer 2021 Simulation 2': 'Szenario mit Maßnahmen',

--- a/frontend/locales/de-backend.json5
+++ b/frontend/locales/de-backend.json5
@@ -277,6 +277,10 @@
   },
   'scenario-names': {
     'Baseline Scenario': 'Basisszenario',
+    'baseline': 'Basisszenario',
+    'closed_schools': 'Geschlossene Schulen',
+    'remote_work': 'Homeoffice',
+    '10p_reduced_contacts ': '10% Kontaktreduzierung',
     'Summer 2021 Simulation 1': 'Szenario ohne Maßnahmen',
     'Summer 2021 Simulation 2': 'Szenario mit Maßnahmen',
   },

--- a/frontend/locales/de-backend.json5
+++ b/frontend/locales/de-backend.json5
@@ -280,7 +280,7 @@
     baseline: 'Basisszenario',
     closed_schools: 'Geschlossene Schulen',
     remote_work: 'Homeoffice',
-    '10p_reduced_contacts ': '10% Kontaktreduzierung',
+    '10p_reduced_contacts': '10% Kontaktreduzierung',
     'Summer 2021 Simulation 1': 'Szenario ohne Maßnahmen',
     'Summer 2021 Simulation 2': 'Szenario mit Maßnahmen',
   },

--- a/frontend/locales/de-global.json5
+++ b/frontend/locales/de-global.json5
@@ -69,6 +69,9 @@
     timeSeries: 'Zeitreihe',
     parameters: 'Parameter',
   },
+  parameters: {
+    'no-parameters': 'Für das ausgewählte Szenario existieren keine Parameter.',
+  },
   today: 'Heute',
   more: 'Mehr',
   less: 'Weniger',

--- a/frontend/locales/en-backend.json5
+++ b/frontend/locales/en-backend.json5
@@ -278,7 +278,7 @@
     baseline: 'Baseline Scenario',
     closed_schools: 'Schools Closed',
     remote_work: 'Home Office',
-    '10p_reduced_contacts ': '10% Reduced Contacts',
+    '10p_reduced_contacts': '10% Reduced Contacts',
     'Summer 2021 Simulation 1': 'Scenario without Interventions',
     'Summer 2021 Simulation 2': 'Scenario with Interventions',
   },

--- a/frontend/locales/en-backend.json5
+++ b/frontend/locales/en-backend.json5
@@ -275,9 +275,9 @@
   },
   'scenario-names': {
     'Baseline Scenario': 'Baseline Scenario',
-    'baseline': 'Baseline Scenario',
-    'closed_schools': 'Schools Closed',
-    'remote_work': 'Home Office',
+    baseline: 'Baseline Scenario',
+    closed_schools: 'Schools Closed',
+    remote_work: 'Home Office',
     '10p_reduced_contacts ': '10% Reduced Contacts',
     'Summer 2021 Simulation 1': 'Scenario without Interventions',
     'Summer 2021 Simulation 2': 'Scenario with Interventions',

--- a/frontend/locales/en-backend.json5
+++ b/frontend/locales/en-backend.json5
@@ -275,6 +275,10 @@
   },
   'scenario-names': {
     'Baseline Scenario': 'Baseline Scenario',
+    'baseline': 'Baseline Scenario',
+    'closed_schools': 'Schools Closed',
+    'remote_work': 'Home Office',
+    '10p_reduced_contacts ': '10% Reduced Contacts',
     'Summer 2021 Simulation 1': 'Scenario without Interventions',
     'Summer 2021 Simulation 2': 'Scenario with Interventions',
   },

--- a/frontend/locales/en-global.json5
+++ b/frontend/locales/en-global.json5
@@ -78,6 +78,9 @@
     timeSeries: 'Time Series',
     parameters: 'Parameters',
   },
+  parameters: {
+    'no-parameters': 'No parameters available for the selected scenario.',
+  },
   today: 'Today',
   more: 'More',
   less: 'Less',

--- a/frontend/src/__tests__/components/ParameterEditor.test.tsx
+++ b/frontend/src/__tests__/components/ParameterEditor.test.tsx
@@ -9,6 +9,7 @@ import i18n from '../../util/i18nForTests';
 import {Provider} from 'react-redux';
 import React from 'react';
 import ParameterEditor from '../../components/ParameterEditor';
+import {selectScenario} from '../../store/DataSelectionSlice';
 
 describe('ParameterEditor', () => {
   test('Editor Loaded', async () => {
@@ -28,6 +29,10 @@ describe('ParameterEditor', () => {
     await screen.findByText('group-filters.groups.age_3');
     await screen.findByText('group-filters.groups.age_4');
     await screen.findByText('group-filters.groups.age_5');
+
+    await screen.findByText('parameters.no-parameters');
+
+    Store.dispatch(selectScenario(1));
 
     await screen.findByText('parameters.Test Parameter 1.symbol');
     await screen.findByText('parameters.Test Parameter 1.description');

--- a/frontend/src/__tests__/mocks/handlers.ts
+++ b/frontend/src/__tests__/mocks/handlers.ts
@@ -4,6 +4,21 @@
 import {http, HttpResponse} from 'msw';
 
 export default [
+  http.get('*/api/v1/simulations/', () => {
+    return HttpResponse.json({
+      results: [
+        {
+          id: 1,
+          name: 'Test Scenario',
+          description: 'Test',
+          startDay: '2024-01-01',
+          numberOfDays: 30,
+          scenario: 'http://localhost:8000/api/v1/scenarios/1/',
+          percentiles: [5, 15, 25, 50, 75, 85, 95],
+        },
+      ],
+    });
+  }),
   http.get('*/api/v1/scenarios/1/', () => {
     return HttpResponse.json({
       results: {

--- a/frontend/src/components/ParameterEditor.tsx
+++ b/frontend/src/components/ParameterEditor.tsx
@@ -93,6 +93,9 @@ export default function ParameterEditor() {
   );
 }
 
+/**
+ * Creates the header row of the parameter editor.
+ */
 function TableHeader(): JSX.Element {
   const {t: tBackend} = useTranslation('backend');
   const {data: groups} = useGetGroupSubcategoriesQuery();

--- a/frontend/src/components/ParameterEditor.tsx
+++ b/frontend/src/components/ParameterEditor.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
 // SPDX-License-Identifier: Apache-2.0
 
-import React, {useCallback} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import TableContainer from '@mui/material/TableContainer';
 import Table from '@mui/material/Table';
 import TableHead from '@mui/material/TableHead';
@@ -14,9 +14,10 @@ import {useTheme} from '@mui/material/styles';
 import Divider from '@mui/material/Divider';
 import Box from '@mui/material/Box';
 import MathMarkdown from './shared/MathMarkdown';
-import {ParameterData, useGetScenarioParametersQuery} from '../store/services/scenarioApi';
+import {ParameterData, useGetScenarioParametersQuery, useGetSimulationsQuery} from '../store/services/scenarioApi';
 import {useTranslation} from 'react-i18next';
 import {useGetGroupSubcategoriesQuery} from '../store/services/groupApi';
+import {useAppSelector} from '../store/hooks';
 
 /**
  * This component visualizes the parameters of the selected scenario. It uses a table with the following format:
@@ -33,7 +34,23 @@ import {useGetGroupSubcategoriesQuery} from '../store/services/groupApi';
 export default function ParameterEditor() {
   const {t} = useTranslation('backend');
   const theme = useTheme();
-  const {data} = useGetScenarioParametersQuery(1);
+
+  const {data: simulations} = useGetSimulationsQuery();
+  const selectedScenario = useAppSelector((state) => state.dataSelection.scenario);
+  const [scenarioId, setScenarioId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const scenario = simulations?.results.find((sim) => sim.id === selectedScenario);
+    const scenarioIdResult = scenario?.scenario.match(/(\d+)(?!.*\d)/);
+    if (scenarioIdResult) {
+      const id = parseInt(scenarioIdResult[0]);
+      setScenarioId(id);
+    } else {
+      setScenarioId(null);
+    }
+  }, [simulations, selectedScenario]);
+
+  const {data} = useGetScenarioParametersQuery(scenarioId);
   const {data: groups} = useGetGroupSubcategoriesQuery();
 
   return (

--- a/frontend/src/components/ParameterEditor.tsx
+++ b/frontend/src/components/ParameterEditor.tsx
@@ -18,6 +18,7 @@ import {ParameterData, useGetScenarioParametersQuery, useGetSimulationsQuery} fr
 import {useTranslation} from 'react-i18next';
 import {useGetGroupSubcategoriesQuery} from '../store/services/groupApi';
 import {useAppSelector} from '../store/hooks';
+import GridOff from '@mui/icons-material/GridOff';
 
 /**
  * This component visualizes the parameters of the selected scenario. It uses a table with the following format:
@@ -32,15 +33,21 @@ import {useAppSelector} from '../store/hooks';
  * be different socio-economic groups, e.g. age.
  */
 export default function ParameterEditor() {
-  const {t} = useTranslation('backend');
+  const {t} = useTranslation();
   const theme = useTheme();
 
-  const {data: simulations} = useGetSimulationsQuery();
-  const selectedScenario = useAppSelector((state) => state.dataSelection.scenario);
   const [scenarioId, setScenarioId] = useState<number | null>(null);
 
+  const selectedScenario = useAppSelector((state) => state.dataSelection.scenario);
+  const {data: simulations} = useGetSimulationsQuery();
+  const {data: parameters} = useGetScenarioParametersQuery(scenarioId);
+
+  // This effect gets the id of the scenario, where the parameters are stored.
   useEffect(() => {
     const scenario = simulations?.results.find((sim) => sim.id === selectedScenario);
+
+    // The scenario id is unfortunately hidden in a URL. It is always the last number in the URL, so we use the
+    // following regex to extract that number.
     const scenarioIdResult = scenario?.scenario.match(/(\d+)(?!.*\d)/);
     if (scenarioIdResult) {
       const id = parseInt(scenarioIdResult[0]);
@@ -50,26 +57,57 @@ export default function ParameterEditor() {
     }
   }, [simulations, selectedScenario]);
 
-  const {data} = useGetScenarioParametersQuery(scenarioId);
-  const {data: groups} = useGetGroupSubcategoriesQuery();
+  if (scenarioId !== null) {
+    return (
+      <TableContainer sx={{background: theme.palette.background.paper, height: '100%'}}>
+        <Table stickyHeader size='small' sx={{position: 'relative'}}>
+          <TableHeader />
+          <TableBody>
+            {parameters?.map((entry) => <ParameterRow key={'row-' + crypto.randomUUID()} params={entry} />)}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    );
+  }
 
   return (
-    <TableContainer sx={{background: theme.palette.background.paper, height: '100%'}}>
-      <Table stickyHeader size='small' sx={{position: 'relative'}}>
-        <TableHead>
-          <TableRow>
-            <ParameterColumHeader colSpan={2} name='Parameter' />
-            {groups?.results // Currently only age groups are supported. We also need to ignore the 'total' group.
-              ?.filter((group) => group.key !== 'total')
-              .filter((group) => group.category === 'age')
-              .map((group) => <ParameterColumHeader key={group.key} name={t(`group-filters.groups.${group.key}`)} />)}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {data?.map((entry) => <ParameterRow key={'row-' + crypto.randomUUID()} params={entry} />)}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <Box sx={{background: theme.palette.background.paper, display: 'flex', flexDirection: 'column', height: '100%'}}>
+      <TableContainer>
+        <Table stickyHeader size='small' sx={{position: 'relative'}}>
+          <TableHeader />
+        </Table>
+      </TableContainer>
+      <Box
+        sx={{
+          margin: 'auto',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+        }}
+      >
+        <GridOff color='primary' fontSize='large' />
+        <Typography variant='body1'>{t('parameters.no-parameters')}</Typography>
+      </Box>
+    </Box>
+  );
+}
+
+function TableHeader(): JSX.Element {
+  const {t: tBackend} = useTranslation('backend');
+  const {data: groups} = useGetGroupSubcategoriesQuery();
+  return (
+    <TableHead>
+      <TableRow>
+        <ParameterColumHeader colSpan={2} name='Parameter' />
+        {groups?.results // Currently only age groups are supported. We also need to ignore the 'total' group.
+          ?.filter((group) => group.key !== 'total')
+          .filter((group) => group.category === 'age')
+          .map((group) => (
+            <ParameterColumHeader key={group.key} name={tBackend(`group-filters.groups.${group.key}`)} />
+          ))}
+      </TableRow>
+    </TableHead>
   );
 }
 

--- a/frontend/src/store/services/scenarioApi.ts
+++ b/frontend/src/store/services/scenarioApi.ts
@@ -108,8 +108,12 @@ export const scenarioApi = createApi({
       },
     }),
 
-    getScenarioParameters: builder.query<Array<ParameterData>, number>({
-      queryFn: async function (arg: number, _queryApi, _extraOptions, fetchWithBQ) {
+    getScenarioParameters: builder.query<Array<ParameterData> | null, number | null>({
+      queryFn: async function (arg: number | null, _queryApi, _extraOptions, fetchWithBQ) {
+        if (!arg) {
+          return {data: null};
+        }
+
         const response = await fetchWithBQ(`scenarios/${arg}/`);
         if (response.error) return {error: response.error};
         const parameters = response.data as ParameterRESTData;


### PR DESCRIPTION
### Description

Previously the scenario parameters were always loading the first parameterset. Now they load the correct one associated with the selected scenario or they show an info message, if no parameters are available for the selected scenario,

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [x] Unit and/or integration tests have been added
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)