### PR TITLE
Fix and Refactor Scenario Colors

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -17,6 +17,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Fehlende Übersetzungen wurden ergänzt.
 - Die Auswahl der Farblegenden zeigt jetzt wieder eine Vorschau für alle Optionen.
+- Die Farben der Szenarien wurden zum Teil falsch berechnet, was zu mehreren Szenarien mit den gleichen Farben führte.
 
 ---
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -17,6 +17,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Missing translations were fixed.
 - The heat legend selection now shows a preview for all legends again.
+- The colors of the scenarios was calculated wrongly which could lead to multiple scenarios with the same colors.
 
 ---
 

--- a/frontend/src/components/Scenario/DataCardList.tsx
+++ b/frontend/src/components/Scenario/DataCardList.tsx
@@ -17,6 +17,7 @@ import {
 import {setCompartments, setScenarios} from '../../store/ScenarioSlice';
 import {useGetSimulationStartValues} from './hooks';
 import {useGetCaseDataByDistrictQuery} from '../../store/services/caseDataApi';
+import {getScenarioPrimaryColor} from '../../util/Theme';
 
 export default function DataCardList(): JSX.Element {
   const theme = useTheme();
@@ -139,13 +140,13 @@ export default function DataCardList(): JSX.Element {
         onClick={() => dispatch(selectScenario(0))}
         onToggle={() => dispatch(toggleScenario(0))}
       />
-      {Object.entries(scenarioList.scenarios).map(([, scenario], i) => (
+      {Object.entries(scenarioList.scenarios).map(([, scenario]) => (
         <ScenarioCard
           key={scenario.id}
           scenario={scenario}
           selected={selectedScenario === scenario.id}
           active={!!activeScenarios && activeScenarios.includes(scenario.id)}
-          color={theme.custom.scenarios[(i + 1) % theme.custom.scenarios.length][0]}
+          color={getScenarioPrimaryColor(scenario.id, theme)}
           startValues={startValues}
           onClick={() => {
             // set active scenario to this one and send dispatches

--- a/frontend/src/components/Scenario/ScenarioCard.tsx
+++ b/frontend/src/components/Scenario/ScenarioCard.tsx
@@ -8,6 +8,7 @@ import {useGetSingleSimulationEntryQuery} from 'store/services/scenarioApi';
 import {Dictionary} from '../../util/util';
 import {useTranslation} from 'react-i18next';
 import {DataCard} from './DataCard';
+import {getScenarioPrimaryColor} from '../../util/Theme';
 
 /** Type definition for the ScenarioCard props */
 interface ScenarioCardProps {
@@ -75,7 +76,7 @@ export function ScenarioCard(props: ScenarioCardProps): JSX.Element {
     <DataCard
       id={props.scenario.id}
       label={tBackend(`scenario-names.${props.scenario.label}`)}
-      color={theme.custom.scenarios[props.scenario.id % theme.custom.scenarios.length][0]}
+      color={getScenarioPrimaryColor(props.scenario.id, theme)}
       selected={props.selected}
       active={props.active}
       compartmentValues={compartmentValues}

--- a/frontend/src/components/Sidebar/HeatLegendEdit.tsx
+++ b/frontend/src/components/Sidebar/HeatLegendEdit.tsx
@@ -92,7 +92,8 @@ export default function HeatLegendEdit(): JSX.Element {
       return;
     }
 
-    const scenarioDefault = defaultLegends[activeScenario % defaultLegends.length];
+    const scenarioDefault =
+      activeScenario === 0 ? defaultLegends[0] : defaultLegends[(activeScenario % (defaultLegends.length - 1)) + 1];
     const legends = [...heatmapLegends];
     legends.unshift(scenarioDefault);
 

--- a/frontend/src/components/SimulationChart.tsx
+++ b/frontend/src/components/SimulationChart.tsx
@@ -32,6 +32,7 @@ import LoadingContainer from './shared/LoadingContainer';
 import {useGetMultipleGroupFilterDataQuery} from 'store/services/groupApi';
 import {GroupData} from 'types/group';
 import {setReferenceDayBottom} from '../store/LayoutSlice';
+import {getScenarioPrimaryColor} from '../util/Theme';
 
 /**
  * React Component to render the Simulation Chart Section
@@ -288,7 +289,7 @@ export default function SimulationChart(): JSX.Element {
           // Add fill color according to selected scenario (if selected scenario is set and it's not case data)
           fill:
             selectedScenario !== null && selectedScenario > 0
-              ? color(theme.custom.scenarios[selectedScenario % theme.custom.scenarios.length][0])
+              ? color(getScenarioPrimaryColor(selectedScenario, theme))
               : undefined,
         })
       );
@@ -315,11 +316,11 @@ export default function SimulationChart(): JSX.Element {
             // Fallback Tooltip (if HTML breaks for some reason)
             // For text color: loop around the theme's scenario color list if scenario IDs exceed color list length, then pick first color of sub-palette which is the main color
             tooltip: Tooltip.new(root, {
-              labelText: `[bold ${theme.custom.scenarios[scenario.id % theme.custom.scenarios.length][0]}]${tBackend(
+              labelText: `[bold ${getScenarioPrimaryColor(scenario.id, theme)}]${tBackend(
                 `scenario-names.${scenario.label}`
               )}:[/] {${scenarioId}}`,
             }),
-            stroke: color(theme.custom.scenarios[scenario.id % theme.custom.scenarios.length][0]),
+            stroke: color(getScenarioPrimaryColor(scenario.id, theme)),
           })
         );
         series.strokes.template.setAll({
@@ -353,11 +354,11 @@ export default function SimulationChart(): JSX.Element {
                 // Fallback Tooltip (if HTML breaks for some reason)
                 // Use color of selected scenario (scenario ID is 1-based index, color list is 0-based index) loop if scenario ID exceeds length of color list; use first color of palette (main color)
                 tooltip: Tooltip.new(root, {
-                  labelText: `[bold ${theme.custom.scenarios[selectedScenario % theme.custom.scenarios.length][0]}]${
+                  labelText: `[bold ${getScenarioPrimaryColor(selectedScenario, theme)}]${
                     groupFilter.name
                   }:[/] {${groupFilter.name}}`,
                 }),
-                stroke: color(theme.custom.scenarios[selectedScenario % theme.custom.scenarios.length][0]),
+                stroke: color(getScenarioPrimaryColor(selectedScenario, theme)),
               })
             );
             series.strokes.template.setAll({

--- a/frontend/src/util/Theme.ts
+++ b/frontend/src/util/Theme.ts
@@ -160,10 +160,16 @@ export default createTheme({
   },
 });
 
+/**
+ * This function assigns a color palette to a scenario and consistently returns the same palette for the same id.
+ */
 export function getScenarioColorPalette(scenarioId: number, theme: Theme): Array<string> {
   return theme.custom.scenarios[(scenarioId % (theme.custom.scenarios.length - 1)) + 1];
 }
 
+/**
+ * This function assigns a primary color to a scenario and consistently returns the same color for the same id.
+ */
 export function getScenarioPrimaryColor(scenarioId: number, theme: Theme): string {
   return getScenarioColorPalette(scenarioId, theme)[0];
 }

--- a/frontend/src/util/Theme.ts
+++ b/frontend/src/util/Theme.ts
@@ -3,7 +3,7 @@
 
 // add List Element typography using module augmentation
 import React from 'react';
-import {createTheme} from '@mui/material/styles';
+import {createTheme, Theme} from '@mui/material/styles';
 
 declare module '@mui/material/styles' {
   interface TypographyVariants {
@@ -159,3 +159,11 @@ export default createTheme({
     ],
   },
 });
+
+export function getScenarioColorPalette(scenarioId: number, theme: Theme): Array<string> {
+  return theme.custom.scenarios[(scenarioId % (theme.custom.scenarios.length - 1)) + 1];
+}
+
+export function getScenarioPrimaryColor(scenarioId: number, theme: Theme): string {
+  return getScenarioColorPalette(scenarioId, theme)[0];
+}


### PR DESCRIPTION
### Description

This PR fixes the colorazation of scenarios. Previously a scenario card could have the same color as the case data. There are now two helper functions to fetch the correct colors.

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [ ] ~~Unit and/or integration tests have been added~~
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] ~~I attached performance measurements to prevent performance degradation~~
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)