### PR TITLE
:wrench: Implement baseline scenario day selection for initial scenar…

### DIFF
--- a/frontend/src/__tests__/store/UserPreferenceSlice.test.ts
+++ b/frontend/src/__tests__/store/UserPreferenceSlice.test.ts
@@ -3,7 +3,12 @@
 
 import {describe, test, expect} from 'vitest';
 
-import reducer, {selectHeatmapLegend, selectTab, UserPreference} from '../../store/UserPreferenceSlice';
+import reducer, {
+  selectHeatmapLegend,
+  selectTab,
+  setInitialVisit,
+  UserPreference,
+} from '../../store/UserPreferenceSlice';
 import {HeatmapLegend} from '../../types/heatmapLegend';
 
 describe('DataSelectionSlice', () => {
@@ -17,6 +22,7 @@ describe('DataSelectionSlice', () => {
       ],
     },
     selectedTab: '1',
+    isInitialVisit: true,
   };
 
   test('Initial State', () => {
@@ -35,6 +41,7 @@ describe('DataSelectionSlice', () => {
     expect(reducer(initialState, selectHeatmapLegend({legend: legend}))).toEqual({
       selectedHeatmap: legend,
       selectedTab: '1',
+      isInitialVisit: true,
     });
   });
 
@@ -49,6 +56,37 @@ describe('DataSelectionSlice', () => {
         ],
       },
       selectedTab: '2',
+      isInitialVisit: true,
+    });
+  });
+
+  test('Set initialVisit to true', () => {
+    expect(reducer(initialState, setInitialVisit(true))).toEqual({
+      selectedHeatmap: {
+        name: 'uninitialized',
+        isNormalized: true,
+        steps: [
+          {color: 'rgb(255,255,255)', value: 0},
+          {color: 'rgb(255,255,255)', value: 1},
+        ],
+      },
+      selectedTab: '1',
+      isInitialVisit: true,
+    });
+  });
+
+  test('Set initialVisit to false', () => {
+    expect(reducer(initialState, setInitialVisit(false))).toEqual({
+      selectedHeatmap: {
+        name: 'uninitialized',
+        isNormalized: true,
+        steps: [
+          {color: 'rgb(255,255,255)', value: 0},
+          {color: 'rgb(255,255,255)', value: 1},
+        ],
+      },
+      selectedTab: '1',
+      isInitialVisit: false,
     });
   });
 });

--- a/frontend/src/store/UserPreferenceSlice.ts
+++ b/frontend/src/store/UserPreferenceSlice.ts
@@ -7,6 +7,7 @@ import {HeatmapLegend} from '../types/heatmapLegend';
 export interface UserPreference {
   selectedHeatmap: HeatmapLegend;
   selectedTab?: string;
+  isInitialVisit: boolean;
 }
 
 const initialState: UserPreference = {
@@ -20,6 +21,7 @@ const initialState: UserPreference = {
     ],
   },
   selectedTab: '1',
+  isInitialVisit: true,
 };
 
 /**
@@ -36,8 +38,12 @@ export const UserPreferenceSlice = createSlice({
     selectTab(state, action: PayloadAction<string>) {
       state.selectedTab = action.payload;
     },
+    /** Set users initial visit to the application */
+    setInitialVisit(state, action: PayloadAction<boolean>) {
+      state.isInitialVisit = action.payload;
+    },
   },
 });
 
-export const {selectHeatmapLegend, selectTab} = UserPreferenceSlice.actions;
+export const {selectHeatmapLegend, selectTab, setInitialVisit} = UserPreferenceSlice.actions;
 export default UserPreferenceSlice.reducer;


### PR DESCRIPTION
…io list

<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description
On initial load we had only case data card activated by default. Made changes to also activate the first scenario card (assuming it to be baseline scenario). The initial date would be the end date available for the particular scenario. Also added startDate and endDate calculating function in DataCardList component for reusability.

#### Related Issues

#364 

### Design Decisions
-

### Performance & Quality
-

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [x] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)