### PR TITLE
:tada: Improve scenario activation and selection.

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Verbesserungen
 
 - Es wurde mehr Übersetzungen für Szenarien hinzugefügt.
+- Wenn ein deaktiviertes Scenario angeklickt wird, wird es automatisch aufgedeckt und selektiert.
 
 ### Fehlerbehebungen
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Improvements
 
 - Added translations for additional scenarios.
+- If an inactive scenario is being clicked on it will automatically be revealed and selected.
 
 ### Bug fixes
 

--- a/frontend/src/components/ScenarioComponents/CardsComponents/MainCard/MainCard.tsx
+++ b/frontend/src/components/ScenarioComponents/CardsComponents/MainCard/MainCard.tsx
@@ -122,9 +122,10 @@ function MainCard({
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       onClick={() => {
-        if (activeScenario) {
-          setSelectedScenario(index);
+        if (!activeScenario) {
+          setActiveScenarios([...(activeScenarios ?? []), index]);
         }
+        setSelectedScenario(index);
       }}
     >
       <Box


### PR DESCRIPTION
### Description

When you click a face down scenario card it now will be activated and selected at the same time. This should improve user interaction.

#### Related Issues

--

### Design Decisions

It was unintuitive to select disabled scenarios, this should streamline this workflow.

### Performance & Quality

This PR is trivial.

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [ ] ~~Unit and/or integration tests have been added~~
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] ~~I attached performance measurements to prevent performance degradation~~
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)