### PR TITLE
Feature/auth backend integration

### DIFF
--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -36,7 +36,7 @@ function AuthProvider({children}: AuthProviderProps) {
         import.meta.env.VITE_OAUTH_REDIRECT_URL === undefined
           ? window.location.origin
           : `${import.meta.env.VITE_OAUTH_REDIRECT_URL}`,
-      scope: 'openid profile email', // default scope without audience
+      scope: 'openid profile email loki-back-audience roles', // default scope without audience
       autoLogin: false,
     };
   }

--- a/frontend/src/components/TopBar/ApplicationMenu.tsx
+++ b/frontend/src/components/TopBar/ApplicationMenu.tsx
@@ -105,8 +105,10 @@ export default function ApplicationMenu(): JSX.Element {
   };
 
   const keycloakLogout = () => {
-    window.location.assign(`${import.meta.env.VITE_OAUTH_API_URL}/realms/${realm}/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURI(import.meta.env.VITE_OAUTH_REDIRECT_URL)}&id_token_hint=${idToken}`);
-  }
+    window.location.assign(
+      `${import.meta.env.VITE_OAUTH_API_URL}/realms/${realm}/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURI(import.meta.env.VITE_OAUTH_REDIRECT_URL)}&id_token_hint=${idToken}`
+    );
+  };
 
   return (
     <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'flex-end'}}>

--- a/frontend/src/components/TopBar/ApplicationMenu.tsx
+++ b/frontend/src/components/TopBar/ApplicationMenu.tsx
@@ -12,7 +12,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/system/Box';
 import {useAppSelector} from 'store/hooks';
 import {AuthContext, IAuthContext} from 'react-oauth2-code-pkce';
-import {useCreateProtectedScenarioMutation} from 'store/services/scenarioApi';
+import ToyCreateProtectedScenarioMenuItem from './ToyCreateProtectedScenarioMenuItem';
 
 const ChangelogDialog = React.lazy(() => import('./PopUps/ChangelogDialog'));
 const ImprintDialog = React.lazy(() => import('./PopUps/ImprintDialog'));
@@ -34,8 +34,6 @@ export default function ApplicationMenu(): JSX.Element {
   const loginDisabled = realm === '';
   // user is authenticated when token is not empty
   const isAuthenticated = token !== '';
-
-  const [createProtectedScenario] = useCreateProtectedScenarioMutation();
 
   const [anchorElement, setAnchorElement] = React.useState<Element | null>(null);
   const [imprintOpen, setImprintOpen] = React.useState(false);
@@ -97,16 +95,10 @@ export default function ApplicationMenu(): JSX.Element {
     setChangelogOpen(true);
   };
 
-  const createProtectedScenarioClicked = () => {
-    createProtectedScenario(token)
-      .unwrap()
-      .then((res) => console.log(res))
-      .catch((err) => console.error(err));
-  };
-
+  /** Redirect user to logout from the IdP (Keycloak) */
   const keycloakLogout = () => {
     window.location.assign(
-      `${import.meta.env.VITE_OAUTH_API_URL}/realms/${realm}/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURI(import.meta.env.VITE_OAUTH_REDIRECT_URL)}&id_token_hint=${idToken}`
+      `${import.meta.env.VITE_OAUTH_API_URL}/realms/${realm}/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURI(`${import.meta.env.VITE_OAUTH_REDIRECT_URL}`)}&id_token_hint=${idToken}`
     );
   };
 
@@ -123,16 +115,16 @@ export default function ApplicationMenu(): JSX.Element {
       </Button>
       <Menu id='application-menu' anchorEl={anchorElement} open={Boolean(anchorElement)} onClose={closeMenu}>
         {isAuthenticated ? (
-          <MenuItem onClick={logoutClicked}>{t('topBar.menu.logout')}</MenuItem>
+          <>
+            <MenuItem onClick={logoutClicked}>{t('topBar.menu.logout')}</MenuItem>
+            <ToyCreateProtectedScenarioMenuItem />
+          </>
         ) : (
           <MenuItem onClick={loginClicked} disabled={loginDisabled}>
             {t('topBar.menu.login')}
           </MenuItem>
         )}
         <Divider />
-        <MenuItem onClick={createProtectedScenarioClicked} disabled={!isAuthenticated}>
-          Create Protected Scenario
-        </MenuItem>
         <MenuItem onClick={imprintClicked}>{t('topBar.menu.imprint')}</MenuItem>
         <MenuItem onClick={privacyPolicyClicked}>{t('topBar.menu.privacy-policy')}</MenuItem>
         <MenuItem onClick={accessibilityClicked}>{t('topBar.menu.accessibility')}</MenuItem>

--- a/frontend/src/components/TopBar/ApplicationMenu.tsx
+++ b/frontend/src/components/TopBar/ApplicationMenu.tsx
@@ -28,7 +28,7 @@ export default function ApplicationMenu(): JSX.Element {
   const {t} = useTranslation();
 
   const realm = useAppSelector((state) => state.realm.name);
-  const {login, token, logOut} = useContext<IAuthContext>(AuthContext);
+  const {login, token, logOut, idToken} = useContext<IAuthContext>(AuthContext);
 
   // user cannot login when realm is not selected
   const loginDisabled = realm === '';
@@ -64,6 +64,7 @@ export default function ApplicationMenu(): JSX.Element {
   const logoutClicked = () => {
     closeMenu();
     logOut();
+    keycloakLogout();
   };
 
   /** This method gets called, when the imprint menu entry was clicked. It opens a dialog showing the legal text. */
@@ -102,6 +103,10 @@ export default function ApplicationMenu(): JSX.Element {
       .then((res) => console.log(res))
       .catch((err) => console.error(err));
   };
+
+  const keycloakLogout = () => {
+    window.location.assign(`${import.meta.env.VITE_OAUTH_API_URL}/realms/${realm}/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURI(import.meta.env.VITE_OAUTH_REDIRECT_URL)}&id_token_hint=${idToken}`);
+  }
 
   return (
     <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'flex-end'}}>

--- a/frontend/src/components/TopBar/ApplicationMenu.tsx
+++ b/frontend/src/components/TopBar/ApplicationMenu.tsx
@@ -115,10 +115,10 @@ export default function ApplicationMenu(): JSX.Element {
       </Button>
       <Menu id='application-menu' anchorEl={anchorElement} open={Boolean(anchorElement)} onClose={closeMenu}>
         {isAuthenticated ? (
-          <>
+          <Box>
             <MenuItem onClick={logoutClicked}>{t('topBar.menu.logout')}</MenuItem>
             <ToyCreateProtectedScenarioMenuItem />
-          </>
+          </Box>
         ) : (
           <MenuItem onClick={loginClicked} disabled={loginDisabled}>
             {t('topBar.menu.login')}

--- a/frontend/src/components/TopBar/ApplicationMenu.tsx
+++ b/frontend/src/components/TopBar/ApplicationMenu.tsx
@@ -12,6 +12,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/system/Box';
 import {useAppSelector} from 'store/hooks';
 import {AuthContext, IAuthContext} from 'react-oauth2-code-pkce';
+import {useCreateProtectedScenarioMutation} from 'store/services/scenarioApi';
 
 const ChangelogDialog = React.lazy(() => import('./PopUps/ChangelogDialog'));
 const ImprintDialog = React.lazy(() => import('./PopUps/ImprintDialog'));
@@ -33,6 +34,8 @@ export default function ApplicationMenu(): JSX.Element {
   const loginDisabled = realm === '';
   // user is authenticated when token is not empty
   const isAuthenticated = token !== '';
+
+  const [createProtectedScenario] = useCreateProtectedScenarioMutation();
 
   const [anchorElement, setAnchorElement] = React.useState<Element | null>(null);
   const [imprintOpen, setImprintOpen] = React.useState(false);
@@ -93,6 +96,13 @@ export default function ApplicationMenu(): JSX.Element {
     setChangelogOpen(true);
   };
 
+  const createProtectedScenarioClicked = () => {
+    createProtectedScenario(token)
+      .unwrap()
+      .then((res) => console.log(res))
+      .catch((err) => console.error(err));
+  };
+
   return (
     <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'flex-end'}}>
       <Button
@@ -113,6 +123,9 @@ export default function ApplicationMenu(): JSX.Element {
           </MenuItem>
         )}
         <Divider />
+        <MenuItem onClick={createProtectedScenarioClicked} disabled={!isAuthenticated}>
+          Create Protected Scenario
+        </MenuItem>
         <MenuItem onClick={imprintClicked}>{t('topBar.menu.imprint')}</MenuItem>
         <MenuItem onClick={privacyPolicyClicked}>{t('topBar.menu.privacy-policy')}</MenuItem>
         <MenuItem onClick={accessibilityClicked}>{t('topBar.menu.accessibility')}</MenuItem>

--- a/frontend/src/components/TopBar/ToyCreateProtectedScenarioMenuItem.tsx
+++ b/frontend/src/components/TopBar/ToyCreateProtectedScenarioMenuItem.tsx
@@ -1,0 +1,20 @@
+import {MenuItem} from '@mui/material';
+import React from 'react';
+import {useContext} from 'react';
+import {AuthContext, IAuthContext} from 'react-oauth2-code-pkce';
+import {useCreateProtectedScenarioMutation} from 'store/services/scenarioApi';
+
+export default function ToyCreateProtectedScenarioMenuItem() {
+  const {token} = useContext<IAuthContext>(AuthContext);
+
+  const [createProtectedScenario] = useCreateProtectedScenarioMutation();
+
+  const createProtectedScenarioClicked = () => {
+    createProtectedScenario(token)
+      .unwrap()
+      .then((res) => alert(JSON.stringify(res)))
+      .catch((err) => alert(JSON.stringify(err)));
+  };
+
+  return <MenuItem onClick={createProtectedScenarioClicked}>Create Protected Scenario</MenuItem>;
+}

--- a/frontend/src/components/TopBar/ToyCreateProtectedScenarioMenuItem.tsx
+++ b/frontend/src/components/TopBar/ToyCreateProtectedScenarioMenuItem.tsx
@@ -1,4 +1,7 @@
-import {MenuItem} from '@mui/material';
+// SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR) and CISPA Helmholtz Center for Information Security
+// SPDX-License-Identifier: Apache-2.0
+
+import MenuItem from '@mui/material/MenuItem';
 import React from 'react';
 import {useContext} from 'react';
 import {AuthContext, IAuthContext} from 'react-oauth2-code-pkce';

--- a/frontend/src/store/services/scenarioApi.ts
+++ b/frontend/src/store/services/scenarioApi.ts
@@ -13,6 +13,7 @@ import {
 /* [CDtemp-begin] */
 import cologneData from '../../../assets/stadtteile_cologne_list.json';
 import {District} from 'types/cologneDistricts';
+import {RootState} from 'store';
 
 /** Checks if input node is a city district and returns the node to fetch data, and the city distrct suffix if there is one */
 function validateDistrictNode(inNode: string): {node: string; cologneDistrict?: string} {
@@ -48,8 +49,29 @@ function modifyDistrictResults(cologneDistrict: string | undefined, data: Simula
 export const scenarioApi = createApi({
   reducerPath: 'scenarioApi',
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-  baseQuery: fetchBaseQuery({baseUrl: `${import.meta.env.VITE_API_URL || ''}/api/v1/`}),
+  baseQuery: fetchBaseQuery({
+    baseUrl: `${import.meta.env.VITE_API_URL || ''}/`,
+    prepareHeaders: (headers, {getState}) => {
+      const realm = (getState() as RootState).realm.name;
+
+      if (realm !== '') {
+        // include realm in req header
+        headers.set('x-realm', realm);
+      }
+
+      return headers;
+    },
+  }),
   endpoints: (builder) => ({
+    createProtectedScenario: builder.mutation<string, string>({
+      query: (token) => ({
+        url: 'scenarios/protected/',
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+    }),
     getSimulationModels: builder.query<SimulationModels, void>({
       query: () => {
         return 'simulationmodels/';
@@ -397,4 +419,5 @@ export const {
   useGetMultipleSimulationDataByNodeQuery,
   useGetPercentileDataQuery,
   useGetScenarioParametersQuery,
+  useCreateProtectedScenarioMutation,
 } = scenarioApi;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

<!--
Describe what is the purpose of this Pull Request:
- Does it resolve a bug?
- Does it implement a new feature?
- Does it improve something existing?

Be as elaborate as possible!
-->

Added trigger in application menu for toy endpoint at the new backend to demonstrate authorization functionality.
A custom request header `X-Realm` is embedded to every request in scenario API service. Because of the OAuth2.0 adapter (`react-oauth2-code-pkce
`) I chose, the authentication context is limited to be stored in a native react context which its content cannot be accessed when defining RTKQuery APIs (only function components can have hooks). The issue is addressed [here](https://github.com/DLR-SC/ESID/issues/387) which can be improved by migrating to `keycloak-js`, a native Keycloak adapter and writing our own store for persisting authentication context. As a result, token as to be passed every time a request is called.

I don't know why I am not passing the ParameterEditor test. Locally, it is not showing on the browser either. Maybe I didn't specify a working backend URI? 

Also fixed bug that logout button only clearing authentication context locally but not logout through IdP. Now after logout locally the page will redirect to Keycloak's logout endpoint.

#### Related Issues

<!--
Add references to the issues addressed in this PR (#<issue number>)
-->
I guess https://github.com/DLR-SC/ESID/issues/206 ?

### Design Decisions

<!--
Please give a short explanation about why you implemented the PR as you did.
Discuss possible alternative implementations that you considered and why you chose this one.

If the PR is trivial you can remove this section.
-->

### Performance & Quality

<!--
Please attach exports from
- React Developer Tools Profiler run
- Performance insights page load measurement
If you have trouble creating them refer to the docs.
If the PR is trivial you may remove this section
-->

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [*] The code is properly formatted (I ran the formatter)
- [*] The code is written with our software quality standards (I ran the linter)
- [*] The code is written using our code style
- [*] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)