### PR TITLE
:tada: Flip up and activate a face down card on clicking anywhere on the card

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Verbesserungen
 
 - Es wurde mehr Übersetzungen für Szenarien hinzugefügt.
+- Inaktive Szenariokarten können nun durch Klicken an beliebiger Stelle auf der Karte aktiviert werden, nicht nur über die Checkbox.
 
 ### Fehlerbehebungen
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Improvements
 
 - Added translations for additional scenarios.
+- Inactive scenario cards can now be activated (flipped face up) by clicking anywhere on the card, not only on the checkbox.
 
 ### Bug fixes
 

--- a/frontend/src/components/ScenarioComponents/CardsComponents/MainCard/MainCard.tsx
+++ b/frontend/src/components/ScenarioComponents/CardsComponents/MainCard/MainCard.tsx
@@ -111,6 +111,9 @@ function MainCard({
       onClick={() => {
         if (isActive) {
           setSelected({id, state: true});
+        } else {
+          setActive({id, state: true});
+          setSelected({id, state: true});
         }
       }}
     >


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description
Make an inactive card active by clicking anywhere on the card rather than by only clicking on the checkbox
<!--
Describe what is the purpose of this Pull Request:
- Does it resolve a bug?
- Does it implement a new feature?
- Does it improve something existing?

Be as elaborate as possible!
-->

User had to click on cardTooltip checkbox to activate a card. It's now changed into click anywhere on the card in the Inactive state to set it to active (or flip up)
#### Related Issues

<!--
Add references to the issues addressed in this PR (#<issue number>)
-->
#396 
### Design Decisions

<!--
Please give a short explanation about why you implemented the PR as you did.
Discuss possible alternative implementations that you considered and why you chose this one.

If the PR is trivial you can remove this section.
-->

### Performance & Quality

<!--
Please attach exports from
- React Developer Tools Profiler run
- Performance insights page load measurement
If you have trouble creating them refer to the docs.
If the PR is trivial you may remove this section
-->

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)