### PR TITLE
:tada: Ensure scenario cards are added face up to dashboard immediately

### DIFF
--- a/frontend/docs/changelog/changelog-de.md
+++ b/frontend/docs/changelog/changelog-de.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Verbesserungen
 
 - Es wurde mehr Übersetzungen für Szenarien hinzugefügt.
+- Szenariokarten, die aus der Bibliothek hinzugefügt oder über den Dialog "Neues Szenario erstellen" erzeugt werden, erscheinen nun direkt aktiviert auf dem Dashboard.
 
 ### Fehlerbehebungen
 

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Improvements
 
 - Added translations for additional scenarios.
+- Scenario cards added from the library or created via the "Create a new Scenario" dialog are now immediately activated and displayed face up on the dashboard.
 
 ### Bug fixes
 

--- a/frontend/src/components/ScenarioComponents/ScenarioLibrary.tsx
+++ b/frontend/src/components/ScenarioComponents/ScenarioLibrary.tsx
@@ -55,7 +55,7 @@ export default function ScenarioLibrary(): JSX.Element {
             state: {
               name: data.name,
               description: data.description,
-              visibility: 'inLibrary',
+              visibility: 'faceUp',
             },
           })
         );
@@ -244,7 +244,7 @@ function LibraryCard(props: Readonly<{id: string; name: string}>): JSX.Element {
               background: '#EEEEEEEE',
             },
           }}
-          onClick={() => dispatch(updateScenario({id: props.id, state: {visibility: 'faceDown'}}))}
+          onClick={() => dispatch(updateScenario({id: props.id, state: {visibility: 'faceUp'}}))}
         >
           <Box
             id={`card-front-${props.id}`}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description
When scenario cards are added from the library, they should immediately be turned face up (active) instead of appearing flipped down in the dashboard.
Additionally, when scenarios are created with the dialog they should immediately be added face up to the dashboard instead of staying in the library to be added manually.

<!--
Describe what is the purpose of this Pull Request:
- Does it resolve a bug?
- Does it implement a new feature?
- Does it improve something existing?

Be as elaborate as possible!
-->
Cards added from the library to the Dashboard are now added faceUp (ie. in activated state). Scenarios created using the "Create a new Scenario" dialog box are added directly to the dashboard in the activated state instead of showing up in the library and user having to manually add it to the dashboard.
#### Related Issues

<!--
Add references to the issues addressed in this PR (#<issue number>)
-->
#395 
### Design Decisions

<!--
Please give a short explanation about why you implemented the PR as you did.
Discuss possible alternative implementations that you considered and why you chose this one.

If the PR is trivial you can remove this section.
-->

### Performance & Quality

<!--
Please attach exports from
- React Developer Tools Profiler run
- Performance insights page load measurement
If you have trouble creating them refer to the docs.
If the PR is trivial you may remove this section
-->

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)