### PR TITLE
:tada: Add color scheme selection to scenario creation

### DIFF
--- a/frontend/locales/de-global.json5
+++ b/frontend/locales/de-global.json5
@@ -94,11 +94,14 @@
       'node-list': 'Regionen',
       'create': 'Szenario Erstellen',
       'cancel': 'Abbrechen',
+      'color': 'Farbschema',
+      'color-option': 'Farbschema {{number}}',
 
       'name-required': 'Der Name muss gesetzt werden!',
       'model-required': 'Ein Modell muss ausgewählt werden!',
       'node-required': 'Eine Region muss ausgewählt werden!',
       'date-order': 'Das Startdatum muss vor dem Enddatum liegen!',
+      'color-required': 'Ein Farbschema muss ausgewählt werden!'
     },
   },
   today: 'Heute',

--- a/frontend/locales/en-global.json5
+++ b/frontend/locales/en-global.json5
@@ -103,11 +103,14 @@
       'node-list': 'Regions',
       'create': 'Create Scenario',
       'cancel': 'Cancel',
+      'color': 'Color Scheme',
+      'color-option': 'Color Scheme {{number}}',
 
       'name-required': 'A name is required!',
       'model-required': 'A model needs to be selected!',
       'node-required': 'A region needs to be selected!',
       'date-order': 'The start date needs to be before the end date!',
+      'color-required': 'A color scheme needs to be selected!'
     }
   },
   today: 'Today',

--- a/frontend/src/DataContext.tsx
+++ b/frontend/src/DataContext.tsx
@@ -117,6 +117,7 @@ export const DataProvider = ({children}: {children: React.ReactNode}) => {
   const referenceDate = useAppSelector((state) => state.dataSelection.simulationStart);
   const selectedDate = useAppSelector((state) => state.dataSelection.date);
   const groupFilters = useAppSelector((state) => state.dataSelection.groupFilters);
+  const scenarioColors = useAppSelector((state) => state.userPreference.scenarioColors);
 
   const {data: scenarios, ...scenariosResult} = useGetScenariosQuery();
   const {data: compartments, ...compartmentsResult} = useGetCompartmentsQuery();
@@ -356,12 +357,13 @@ export const DataProvider = ({children}: {children: React.ReactNode}) => {
     }
 
     scenarios?.forEach((scenario, index) => {
-      if (scenario.id !== caseDataScenario?.id) {
+      // prevent overwriting colors
+      if (scenario.id !== caseDataScenario?.id && !scenarioColors[scenario.id]) {
         const colorIndex = (index + 1) % theme.custom.scenarios.length; // +1 to avoid using the first predefined color set
         dispatch(updateScenario({id: scenario.id, state: {colors: theme.custom.scenarios[colorIndex]}}));
       }
     });
-  }, [caseDataScenario, dispatch, dataLoadingCompleted, scenarios]);
+  }, [caseDataScenario, dispatch, dataLoadingCompleted, scenarios, scenarioColors]);
 
   // If we have no selected compartment, we try to set the first one as selected.
   useEffect(() => {

--- a/frontend/src/components/ScenarioComponents/NewScenarioDialog.tsx
+++ b/frontend/src/components/ScenarioComponents/NewScenarioDialog.tsx
@@ -24,6 +24,7 @@ interface ScenarioFormProps {
   models: string[];
   npiOptions: Array<{id: string; name: string}>;
   nodeOptions: string[];
+  colorOptions: string[][];
   onSubmit: (scenarioData: NewScenarioData | null) => void;
 }
 
@@ -35,9 +36,16 @@ export interface NewScenarioData {
   endDate: string;
   npis: string[];
   selectedNode: string;
+  colors: string[];
 }
 
-export default function NewScenarioDialog({models, npiOptions, nodeOptions, onSubmit}: ScenarioFormProps) {
+export default function NewScenarioDialog({
+  models,
+  npiOptions,
+  nodeOptions,
+  onSubmit,
+  colorOptions,
+}: ScenarioFormProps) {
   const {t} = useTranslation();
   const {t: tBackend} = useTranslation('backend');
 
@@ -49,6 +57,7 @@ export default function NewScenarioDialog({models, npiOptions, nodeOptions, onSu
     endDate: dateToISOString(dayjs().add(4, 'week').add(1, 'day').toDate()),
     npis: [],
     selectedNode: nodeOptions[0],
+    colors: [],
   });
 
   const [errors, setErrors] = React.useState<Partial<Record<keyof NewScenarioData, string>>>({});
@@ -67,6 +76,9 @@ export default function NewScenarioDialog({models, npiOptions, nodeOptions, onSu
     }
     if (dayjs(formData.endDate).isBefore(dayjs(formData.startDate))) {
       newErrors.endDate = t('scenario-library.new.date-order');
+    }
+    if (!formData.colors || formData.colors.length === 0) {
+      newErrors.colors = t('scenario-library.new.color-required');
     }
 
     setErrors(newErrors);
@@ -147,6 +159,40 @@ export default function NewScenarioDialog({models, npiOptions, nodeOptions, onSu
           }
         />
       </Box>
+
+      <FormControl fullWidth margin='normal' error={!!errors.colors} required>
+        <InputLabel>{t('scenario-library.new.color')}</InputLabel>
+        <Select
+          value={formData.colors[0]}
+          label={t('scenario-library.new.color')}
+          onChange={(e) => {
+            const selectedColorSet = colorOptions.find((set) => set[0] === e.target.value);
+            if (selectedColorSet) {
+              setFormData((prev) => ({...prev, colors: selectedColorSet}));
+            }
+          }}
+          MenuProps={{
+            disablePortal: true,
+          }} // this is somehow needed to prevent the select menu not being able to show and close the parent dialog
+        >
+          {colorOptions.map((colorSet, index) => (
+            <MenuItem key={index} value={colorSet[0]}>
+              <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
+                <Box
+                  sx={{
+                    width: '15px',
+                    height: '15px',
+                    backgroundColor: colorSet[1],
+                    border: '1px solid #ccc',
+                    borderRadius: '4px',
+                  }}
+                />
+                <Typography>{t('scenario-library.new.color-option', {number: index + 1})}</Typography>
+              </Box>
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
 
       <FormControl fullWidth margin='normal' error={!!errors.npis} required>
         <Typography variant='subtitle1' gutterBottom>

--- a/frontend/src/components/ScenarioComponents/NewScenarioDialog.tsx
+++ b/frontend/src/components/ScenarioComponents/NewScenarioDialog.tsx
@@ -187,12 +187,11 @@ export default function NewScenarioDialog({
 
         <ToggleButtonGroup
           fullWidth
-          color='success'
           value={formData.colors[0]}
           exclusive
           onChange={handleColorChange}
           sx={{
-            border: errors.colors ? theme.palette.error.main : '1px solid #ccc',
+            border: errors.colors ? `1px solid ${theme.palette.error.main}` : '1px solid #ccc',
           }}
         >
           {colorOptions.map((colorSet, index) => (

--- a/frontend/src/components/ScenarioComponents/NewScenarioDialog.tsx
+++ b/frontend/src/components/ScenarioComponents/NewScenarioDialog.tsx
@@ -14,11 +14,14 @@ import {
   Checkbox,
   Button,
   Typography,
+  ToggleButtonGroup,
+  ToggleButton,
 } from '@mui/material';
 import {DatePicker} from '@mui/x-date-pickers/DatePicker';
 import {dateToISOString} from '../../util/util';
 import dayjs, {Dayjs} from 'dayjs';
 import {useTranslation} from 'react-i18next';
+import {useTheme} from '@mui/material/styles';
 
 interface ScenarioFormProps {
   models: string[];
@@ -48,6 +51,7 @@ export default function NewScenarioDialog({
 }: ScenarioFormProps) {
   const {t} = useTranslation();
   const {t: tBackend} = useTranslation('backend');
+  const theme = useTheme();
 
   const [formData, setFormData] = React.useState<NewScenarioData>({
     name: '',
@@ -108,6 +112,16 @@ export default function NewScenarioDialog({
     }));
   };
 
+  const handleColorChange = (_event: React.MouseEvent<HTMLElement>, color: string) => {
+    const selectedColorSet = colorOptions.find((set) => set[0] === color);
+    if (selectedColorSet) {
+      setFormData((prev) => ({
+        ...prev,
+        colors: selectedColorSet,
+      }));
+    }
+  };
+
   return (
     <Box component='form' onSubmit={handleSubmit} onReset={handleReset} sx={{margin: '16px', p: 2}}>
       <Typography variant='h5' gutterBottom>
@@ -161,37 +175,49 @@ export default function NewScenarioDialog({
       </Box>
 
       <FormControl fullWidth margin='normal' error={!!errors.colors} required>
-        <InputLabel>{t('scenario-library.new.color')}</InputLabel>
-        <Select
-          value={formData.colors[0]}
-          label={t('scenario-library.new.color')}
-          onChange={(e) => {
-            const selectedColorSet = colorOptions.find((set) => set[0] === e.target.value);
-            if (selectedColorSet) {
-              setFormData((prev) => ({...prev, colors: selectedColorSet}));
-            }
+        <Typography
+          variant='subtitle1'
+          gutterBottom
+          sx={{
+            color: errors.colors ? theme.palette.error.main : 'inherit',
           }}
-          MenuProps={{
-            disablePortal: true,
-          }} // this is somehow needed to prevent the select menu not being able to show and close the parent dialog
+        >
+          {t('scenario-library.new.color')}
+        </Typography>
+
+        <ToggleButtonGroup
+          fullWidth
+          color='success'
+          value={formData.colors[0]}
+          exclusive
+          onChange={handleColorChange}
+          sx={{
+            border: errors.colors ? theme.palette.error.main : '1px solid #ccc',
+          }}
         >
           {colorOptions.map((colorSet, index) => (
-            <MenuItem key={index} value={colorSet[0]}>
+            <ToggleButton
+              key={index}
+              value={colorSet[0]}
+              aria-label={`Color ${index + 1}`}
+              sx={{
+                border: '0',
+              }}
+            >
               <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
                 <Box
                   sx={{
-                    width: '15px',
-                    height: '15px',
+                    width: '25px',
+                    height: '25px',
                     backgroundColor: colorSet[1],
-                    border: '1px solid #ccc',
+                    border: '0.5px solid #ccc',
                     borderRadius: '4px',
                   }}
                 />
-                <Typography>{t('scenario-library.new.color-option', {number: index + 1})}</Typography>
               </Box>
-            </MenuItem>
+            </ToggleButton>
           ))}
-        </Select>
+        </ToggleButtonGroup>
       </FormControl>
 
       <FormControl fullWidth margin='normal' error={!!errors.npis} required>

--- a/frontend/src/components/ScenarioComponents/ScenarioLibrary.tsx
+++ b/frontend/src/components/ScenarioComponents/ScenarioLibrary.tsx
@@ -23,7 +23,7 @@ import NewScenarioDialog, {NewScenarioData} from './NewScenarioDialog';
 import {InterventionTemplates, Models, NodeLists, Scenario} from '../../store/services/APITypes';
 import {useGetMultiScenariosQuery} from '../../store/services/scenarioApi';
 import {updateScenario} from '../../store/DataSelectionSlice';
-
+import {setScenarioColors} from '../../store/UserPreferenceSlice';
 export default function ScenarioLibrary(): JSX.Element {
   const dispatch = useAppDispatch();
   const {t} = useTranslation();
@@ -56,7 +56,14 @@ export default function ScenarioLibrary(): JSX.Element {
               name: data.name,
               description: data.description,
               visibility: 'faceUp',
+              colors: data.colors,
             },
+          })
+        );
+        dispatch(
+          setScenarioColors({
+            scenarioId: result.id,
+            colors: data.colors,
           })
         );
       }
@@ -200,6 +207,20 @@ function LibraryCard(props: Readonly<{id: string; name: string}>): JSX.Element {
   const dispatch = useAppDispatch();
   const theme = useTheme();
   const {t: tBackend, i18n} = useTranslation('backend');
+  const scenarioColors = useAppSelector((state) => state.userPreference.scenarioColors);
+
+  const handleRestore = () => {
+    const savedColors = scenarioColors[props.id];
+    dispatch(
+      updateScenario({
+        id: props.id,
+        state: {
+          visibility: 'faceUp',
+          colors: savedColors,
+        },
+      })
+    );
+  };
 
   return (
     <Box
@@ -244,7 +265,7 @@ function LibraryCard(props: Readonly<{id: string; name: string}>): JSX.Element {
               background: '#EEEEEEEE',
             },
           }}
-          onClick={() => dispatch(updateScenario({id: props.id, state: {visibility: 'faceUp'}}))}
+          onClick={handleRestore}
         >
           <Box
             id={`card-front-${props.id}`}
@@ -385,6 +406,7 @@ function NewScenarioCard({
             };
           })}
           nodeOptions={[nodeLists[0]?.name ?? 'Districts of Germany']}
+          colorOptions={theme.custom.scenarios}
           onSubmit={(data) => {
             if (data) {
               scenarioCreated(data);

--- a/frontend/src/components/ScenarioComponents/ScenarioLibrary.tsx
+++ b/frontend/src/components/ScenarioComponents/ScenarioLibrary.tsx
@@ -406,7 +406,7 @@ function NewScenarioCard({
             };
           })}
           nodeOptions={[nodeLists[0]?.name ?? 'Districts of Germany']}
-          colorOptions={theme.custom.scenarios}
+          colorOptions={theme.custom.scenarios.slice(1)}
           onSubmit={(data) => {
             if (data) {
               scenarioCreated(data);

--- a/frontend/src/store/UserPreferenceSlice.ts
+++ b/frontend/src/store/UserPreferenceSlice.ts
@@ -8,6 +8,7 @@ export interface UserPreference {
   selectedHeatmap: HeatmapLegend;
   selectedTab?: string;
   isInitialVisit: boolean;
+  scenarioColors: Record<string, string[]>;
 }
 
 const initialState: UserPreference = {
@@ -22,6 +23,7 @@ const initialState: UserPreference = {
   },
   selectedTab: '1',
   isInitialVisit: true,
+  scenarioColors: {},
 };
 
 /**
@@ -42,8 +44,15 @@ export const UserPreferenceSlice = createSlice({
     setInitialVisit(state, action: PayloadAction<boolean>) {
       state.isInitialVisit = action.payload;
     },
+    /** Set colors for a specific scenario */
+    setScenarioColors(state, action: PayloadAction<{scenarioId: string; colors: string[]}>) {
+      if (!state.scenarioColors) {
+        state.scenarioColors = {};
+      }
+      state.scenarioColors[action.payload.scenarioId] = action.payload.colors;
+    },
   },
 });
 
-export const {selectHeatmapLegend, selectTab, setInitialVisit} = UserPreferenceSlice.actions;
+export const {selectHeatmapLegend, selectTab, setInitialVisit, setScenarioColors} = UserPreferenceSlice.actions;
 export default UserPreferenceSlice.reducer;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

Added a feature to select color schemes when creating new scenarios and updates the user preferences to persist these color selections.

The color schemes are selectable in the Dialog when making new scenarios after the date.

#### Related Issues

#392 

### Design Decisions

saved selected Colors state in the user preference slice, then loads it in the DataContext and made sure to not overwrite existing scenario selected custom colors. Made sure to load the color when updating visibility state when hidden

Also added a line of code in the Select MUI Component to prevent Dialog and Dropdown menu to close after clicking it.
```
MenuProps={{
    disablePortal: true, // <--- HERE
}}
```

### Performance & Quality

<!--
Please attach exports from
- React Developer Tools Profiler run
- Performance insights page load measurement
If you have trouble creating them refer to the docs.
If the PR is trivial you may remove this section
-->

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)