### PR TITLE
:tada: Login org. selection now loads dynamically from IdP API

### DIFF
--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -4,15 +4,18 @@
 # This is for development only. For production you need to replace this with the actual URL.
 VITE_API_URL=http://localhost:8000
 
-# IDP Settings
+###### IDP Settings ######
+# Change accordingly for dev, staging or production
 
 # IDP URL
-VITE_OAUTH_API_URL=https://lokiam.de
+VITE_OAUTH_API_URL=https://dev.lokiam.de
 
 # IDP Client ID
-# Dev only, change me for staging or production
 VITE_OAUTH_CLIENT_ID=loki-front-dev
 
 # IDP Redirect URL
 # Dev only, change me for staging or production
 VITE_OAUTH_REDIRECT_URL=http://localhost:5443
+
+# IDP Admin API URL
+VITE_IDP_API_URL=https://api.dev.lokiam.de

--- a/frontend/docs/changelog/changelog-en.md
+++ b/frontend/docs/changelog/changelog-en.md
@@ -20,6 +20,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Added translations for additional scenarios.
 - If an inactive scenario is being clicked on it will automatically be revealed and selected.
+- Instead of hard-coded organizations, now organization dropdown options are populated by fetching the actual realms.
 
 ### Bug fixes
 

--- a/frontend/locales/de-global.json5
+++ b/frontend/locales/de-global.json5
@@ -8,6 +8,7 @@
     'icon-alt': 'ESID Anwendungslogo',
     language: 'Sprache',
     org: 'Organisation',
+    noOrg: 'Leer',
     menu: {
       label: 'Anwendungsmenü',
       login: 'Anmelden',

--- a/frontend/locales/en-global.json5
+++ b/frontend/locales/en-global.json5
@@ -8,6 +8,7 @@
     'icon-alt': 'ESID application logo',
     language: 'Language',
     org: 'Organization',
+    noOrg: 'Empty',
     menu: {
       label: 'Application menu',
       login: 'Login',

--- a/frontend/src/components/TopBar/RealmSelect.tsx
+++ b/frontend/src/components/TopBar/RealmSelect.tsx
@@ -7,23 +7,50 @@ import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import {useAppDispatch, useAppSelector} from 'store/hooks';
-import {setRealm} from 'store/RealmSlice';
+import {setAvailableRealms, setRealm} from 'store/RealmSlice';
 import {useTranslation} from 'react-i18next';
 import Box from '@mui/material/Box';
+import {useLazyGetRealmsQuery} from 'store/services/idpApi';
+import CircularProgress from '@mui/material/CircularProgress';
 
 function RealmSelect() {
   const {t} = useTranslation();
-
-  const realm = useAppSelector((state) => state.realm.name);
   const dispatch = useAppDispatch();
 
-  // realms are hardcoded for now
-  // TODO: should be fetched from keycloak
-  const realms = [
-    {id: 'lha-a', name: 'LHA A', disabled: false},
-    {id: 'lha-b', name: 'LHA B', disabled: true},
-    {id: 'lha-c', name: 'LHA C', disabled: true},
-  ];
+  // use triggerGetRealms to explicitly fetch realms
+  const [triggerGetRealms] = useLazyGetRealmsQuery();
+
+  // select menu items (i.e. organizations/realms) loading state
+  const [realmListLoading, setRealmListLoading] = React.useState(false);
+
+  // a list of available organizations/realms
+  const realmList = useAppSelector((state) => state.realm.avalableRealms);
+
+  // user selected organization/realm
+  const realm = useAppSelector((state) => state.realm.name);
+
+  // this is called when the user opens the select menu
+  const handleSelectOpen = () => {
+    setRealmListLoading(true);
+    triggerGetRealms()
+      .unwrap()
+      .then((realmReprs) => {
+        const newRealmList = realmReprs
+          .filter((r) => r.enabled)
+          .map((r) => ({
+            id: r.realm,
+            name: r.displayName ?? r.realm,
+          }));
+        dispatch(setAvailableRealms(newRealmList));
+      })
+      .catch((err) => {
+        console.error('Failed to fetch realms:', err);
+      })
+      .finally(() => {
+        setRealmListLoading(false);
+      });
+  };
+  console.log(realmList);
 
   return (
     <Box sx={{my: 2}}>
@@ -32,15 +59,35 @@ function RealmSelect() {
         <Select
           labelId='login-dialog-realm-select-label'
           id='login-dialog-realm-select'
-          value={realm}
+          // MUI Select checks for if value matches with child menu item values
+          // It throws a warning if the value is not presented
+          // Since we have two placeholder values (loading and no org),
+          // we need to safe set the value to empty in both cases.
+          value={!realmListLoading && realmList.map((r) => r.id).includes(realm) ? realm : ''}
           onChange={(event) => dispatch(setRealm(event.target.value))}
           label={t('topBar.org')}
+          onOpen={handleSelectOpen}
         >
-          {realms.map((realm) => (
-            <MenuItem key={realm.id} value={realm.id} disabled={realm.disabled}>
-              {realm.name}
+          {realmListLoading && (
+            // Show loading spinner when fetching realms
+            // ph stands for placeholder
+            <MenuItem value='ph-loading' disabled>
+              <CircularProgress />
             </MenuItem>
-          ))}
+          )}
+          {!realmListLoading && realmList.length === 0 && (
+            // Show Empty when no realms are available
+            <MenuItem value='ph-no-org' disabled>
+              <em>{t('topBar.noOrg')}</em>
+            </MenuItem>
+          )}
+          {!realmListLoading &&
+            realmList.length > 0 &&
+            realmList.map((realm) => (
+              <MenuItem key={realm.id} value={realm.id}>
+                {realm.name}
+              </MenuItem>
+            ))}
         </Select>
       </FormControl>
     </Box>

--- a/frontend/src/components/TopBar/RealmSelect.tsx
+++ b/frontend/src/components/TopBar/RealmSelect.tsx
@@ -50,7 +50,6 @@ function RealmSelect() {
         setRealmListLoading(false);
       });
   };
-  console.log(realmList);
 
   return (
     <Box sx={{my: 2}}>

--- a/frontend/src/store/RealmSlice.ts
+++ b/frontend/src/store/RealmSlice.ts
@@ -5,10 +5,17 @@ import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
 export interface Realm {
   name: string;
+  avalableRealms: RealmSelectItem[];
+}
+
+export interface RealmSelectItem {
+  id: string;
+  name: string;
 }
 
 const initialState: Realm = {
   name: '',
+  avalableRealms: [],
 };
 
 export const RealmSlice = createSlice({
@@ -18,8 +25,11 @@ export const RealmSlice = createSlice({
     setRealm(state, action: PayloadAction<string>) {
       state.name = action.payload;
     },
+    setAvailableRealms(state, action: PayloadAction<RealmSelectItem[]>) {
+      state.avalableRealms = action.payload;
+    },
   },
 });
 
-export const {setRealm} = RealmSlice.actions;
+export const {setRealm, setAvailableRealms} = RealmSlice.actions;
 export default RealmSlice.reducer;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -13,6 +13,7 @@ import {groupApi} from './services/groupApi';
 import LayoutReducer from './LayoutSlice';
 import RealmReducer from './RealmSlice';
 import UserOnboardingReducer from './UserOnboardingSlice';
+import {idpApi} from './services/idpApi';
 
 const persistConfig = {
   key: 'root',
@@ -30,6 +31,7 @@ const rootReducer = combineReducers({
   [caseDataApi.reducerPath]: caseDataApi.reducer,
   [scenarioApi.reducerPath]: scenarioApi.reducer,
   [groupApi.reducerPath]: groupApi.reducer,
+  [idpApi.reducerPath]: idpApi.reducer,
 });
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 
@@ -40,7 +42,7 @@ export const Store = configureStore({
       serializableCheck: {
         ignoredActions: ['persist/PERSIST'],
       },
-    }).concat(caseDataApi.middleware, scenarioApi.middleware, groupApi.middleware),
+    }).concat(caseDataApi.middleware, scenarioApi.middleware, groupApi.middleware, idpApi.middleware),
 });
 
 export const Persistor = persistStore(Store);

--- a/frontend/src/store/services/idpApi.ts
+++ b/frontend/src/store/services/idpApi.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
+// SPDX-License-Identifier: Apache-2.0
+
+import {createApi, fetchBaseQuery} from '@reduxjs/toolkit/query/react';
+import {RealmRepresentation} from 'types/realmRepresentation';
+
+export const idpApi = createApi({
+  reducerPath: 'idpApi',
+  baseQuery: fetchBaseQuery({baseUrl: `${import.meta.env.VITE_IDP_API_URL || ''}/`}),
+  endpoints: (build) => ({
+    getRealms: build.query<RealmRepresentation[], void>({
+      query: () => `realms`,
+    }),
+  }),
+});
+
+export const {useLazyGetRealmsQuery} = idpApi;

--- a/frontend/src/types/realmRepresentation.ts
+++ b/frontend/src/types/realmRepresentation.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR) and CISPA Helmholtz Center for Information Security
+// SPDX-License-Identifier: Apache-2.0
+
+export interface RealmRepresentation {
+  realm: string;
+  id?: string;
+  displayName?: string;
+  displayNameHtml?: string;
+  enabled?: boolean;
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

Instead of hard coding organization select options, now the available organizations are fetched via a new API hosted together with our IdP that exposes enabled realms.

#### Related Issues

None

### Design Decisions

I didn't use Keycloak's Admin API directly at ESID's frontend since that will expose client credentials in the browser and I didn't want to use ESID's backend as the back channel to request realms because it is simply not responsible for user management thus I chose to setup my own to decouple the functionalities.

### Performance & Quality

Now user can open the dropdown. The realms will reload with a loading sign and a emtpy item will be shown if there aren't any realm/organization available. The available realm/organization list is also cached with redux's persist reducer.

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [x] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [x] I attached performance measurements to prevent performance degradation
- [x] I added the changes to the next release section of the [changelog](../frontend/docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [x] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../frontend/docs/changelog/changelog-en.md)