### PR TITLE
:beetle: Fix a bug, where data was shown while no scenario was active.

### DIFF
--- a/docs/changelog/changelog-de.md
+++ b/docs/changelog/changelog-de.md
@@ -26,6 +26,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Fehlerbehebungen
 
 - Die robustere Validierung eliminiert einen Großteil der Fehler.
+- Ein Fehler wurde behoben, wo Daten angezeigt wurden, obwohl kein Szenario aufgedeckt war.
 
 ---
 

--- a/docs/changelog/changelog-en.md
+++ b/docs/changelog/changelog-en.md
@@ -26,6 +26,7 @@ SPDX-License-Identifier: CC-BY-4.0
 ### Bug fixes
 
 - More robust validation of the application state should eliminate a wide variety of bugs.
+- A bug was fixed where data was shown while no scenario was active.
 
 ---
 

--- a/src/context/SelectedDataContext.tsx
+++ b/src/context/SelectedDataContext.tsx
@@ -168,7 +168,7 @@ export default function SelectedDataContext(props: {baseData: BaseData; children
   );
 
   // Fetch line chart data
-  const {data: lineChartData} = useGetMultiScenarioInfectionDataQuery(
+  const {currentData: lineChartData} = useGetMultiScenarioInfectionDataQuery(
     {
       pathIds: faceUpScenarios,
       query: {
@@ -178,12 +178,12 @@ export default function SelectedDataContext(props: {baseData: BaseData; children
       },
     },
     {
-      skip: !totalGroup || faceUpScenarios.length === 0,
+      skip: !totalGroup,
     }
   );
 
   // Fetch map data
-  const {data: mapData} = useGetScenarioInfectionDataQuery(
+  const {currentData: mapData} = useGetScenarioInfectionDataQuery(
     {
       path: {scenarioId: selectedScenario!},
       query: {
@@ -193,7 +193,7 @@ export default function SelectedDataContext(props: {baseData: BaseData; children
         groups: totalGroup ? [totalGroup.id] : [],
       },
     },
-    {skip: !totalGroup}
+    {skip: !totalGroup || !selectedScenario}
   );
 
   const contextValue: DataContextType = useMemo(


### PR DESCRIPTION
### Description

Fix a bug, where data was shown while no scenario was active.

#### Related Issues

--

### Design Decisions

Instead of using the `data` field returned by the queries I use the `currentData` field, which is empty when the `skip` value is true.

### Performance & Quality

--

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] ~~Extensive in source documentation has been added~~
- [ ] ~~Unit and/or integration tests have been added~~
- [ ] ~~All texts have been internationalized with at least the following languages:~~
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] ~~I attached performance measurements to prevent performance degradation~~
- [x] I added the changes to the next release section of the [changelog](../docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [x] I checked that the changes are noted in the [changelog](../docs/changelog/changelog-en.md)
