### PR TITLE
dynamic y-axis scale

### DIFF
--- a/docs/changelog/changelog-de.md
+++ b/docs/changelog/changelog-de.md
@@ -18,6 +18,7 @@ SPDX-License-Identifier: CC-BY-4.0
   - Nutzer können benutzerdefinierte Schwellenwerte für aktuell ausgewählte Bezirk und Kompartiment festlegen, die über den Einstellungsbutton in der unteren linken Ecke des Liniendiagramms erreicht werden
   - Die horizontale Schwellenlinie wird als rote Linie im Diagramm angezeigt und Werte über der Schwellenlinie werden in rot angezeigt
   - Nutzer können Schwellenwerte auswählen, um zu den entsprechenden Bezirk und Kompartiment zu navigieren
+- Nutzer können die Skalierung der Y-Achse manuell verändern (Maximalwert einstellen).
 
 ### Verbesserungen
 
@@ -31,7 +32,6 @@ SPDX-License-Identifier: CC-BY-4.0
   - In der Bibliothek, wenn die Maus über eine Karte hovered.
   - Auf der Hauptseite über den Infobutton unter der Karte.
 - Angemeldete Admin-Benutzer können jetzt auf die Schaltfläche Admin im Anwendungsmenü klicken und auf die Benutzerverwaltung zugreifen.
-- Nutzer können die Skalierung der Y-Achse manuell verändern (Maximalwert einstellen).
 
 ### Fehlerbehebungen
 

--- a/docs/changelog/changelog-de.md
+++ b/docs/changelog/changelog-de.md
@@ -31,6 +31,7 @@ SPDX-License-Identifier: CC-BY-4.0
   - In der Bibliothek, wenn die Maus über eine Karte hovered.
   - Auf der Hauptseite über den Infobutton unter der Karte.
 - Angemeldete Admin-Benutzer können jetzt auf die Schaltfläche Admin im Anwendungsmenü klicken und auf die Benutzerverwaltung zugreifen.
+- Nutzer können die Skalierung der Y-Achse manuell verändern (Maximalwert einstellen).
 
 ### Fehlerbehebungen
 

--- a/docs/changelog/changelog-en.md
+++ b/docs/changelog/changelog-en.md
@@ -18,6 +18,7 @@ SPDX-License-Identifier: CC-BY-4.0
   - Users can set custom threshold values for currently selected district and compartment accessible via the settings button on the lower left corner of the line chart
   - The horizontal threshold is displayed as a red horizontal line on the chart and values above the threshold are displayed in red
   - Users can select thresholds to navigate to the corresponding district and compartment
+- Users can now change the scaling of the Y-Axis by setting a maximum value.
 
 ### Improvements
 
@@ -31,7 +32,6 @@ SPDX-License-Identifier: CC-BY-4.0
   - In the library when hovering over a card with the mouse.
   - On the main page via the info button below the card.
 - Logged in admin users can now click on the Admin button in the application menu and access the user management.
-- Users can now change the scaling of the Y-Axis by setting a maximum value.
 
 ### Bug fixes
 

--- a/docs/changelog/changelog-en.md
+++ b/docs/changelog/changelog-en.md
@@ -31,6 +31,7 @@ SPDX-License-Identifier: CC-BY-4.0
   - In the library when hovering over a card with the mouse.
   - On the main page via the info button below the card.
 - Logged in admin users can now click on the Admin button in the application menu and access the user management.
+- Users can now change the scaling of the Y-Axis by setting a maximum value.
 
 ### Bug fixes
 

--- a/locales/de-settings.json5
+++ b/locales/de-settings.json5
@@ -3,6 +3,8 @@
 
 {
   title: 'Liniendiagramm Einstellungen',
+  yAxisMaxValue: 'Y-Achse Maximum',
+  yAxisMaxValueDescription: 'Setzen Sie den Maximalwert für die Y-Achse',
   manageGroups: 'Filter',
   manageGroupsDescription: 'Verwalten Sie Filtergruppen, um spezifische Daten im Diagramm anzuzeigen oder auszublenden.',
   manageThreshold: 'Schwellwerte',
@@ -13,6 +15,18 @@
     compartment: 'Infektionsstatus',
     threshold: 'Schwellwert',
     noThresholds: 'Keine Schwellwerte festgelegt.',
+  },
+  'y-axis-settings': {
+    title: 'Y-Achse Maximum',
+    editTooltip: 'Y-Achse Maximum bearbeiten',
+    resetTooltip: 'Y-Achse Maximum auf aktuellen Daten-Maximalwert zurücksetzen',
+    messages: {
+      success: 'Y-Achse Maximum erfolgreich aktualisiert.',
+      error: 'Ungültige Eingabe. Bitte überprüfen Sie den Wert.',
+    },
+    validation: {
+      positiveNumber: 'Wert muss eine positive Zahl sein',
+    },
   },
   'group-filters': {
     title: 'Gruppen verwalten',

--- a/locales/de-settings.json5
+++ b/locales/de-settings.json5
@@ -25,7 +25,7 @@
       error: 'Ungültige Eingabe. Bitte überprüfen Sie den Wert.',
     },
     validation: {
-      positiveNumber: 'Wert muss eine positive Zahl sein',
+      positiveNumber: 'Der Wert muss eine positive Zahl sein',
     },
   },
   'group-filters': {

--- a/locales/en-settings.json5
+++ b/locales/en-settings.json5
@@ -3,6 +3,8 @@
 
 {
   title: 'Line Chart Settings',
+  yAxisMaxValue: 'Y-Axis Maximum',
+  yAxisMaxValueDescription: 'Set the maximum value for the Y-axis',
   manageGroups: 'Filters',
   manageGroupsDescription: 'Set the group filters for each scenario',
   manageThreshold: 'Thresholds',
@@ -13,6 +15,18 @@
     compartment: 'Compartment',
     threshold: 'Threshold',
     noThresholds: 'No thresholds set.',
+  },
+  'y-axis-settings': {
+    title: 'Y-Axis Maximum',
+    editTooltip: 'Edit Y-Axis Maximum',
+    resetTooltip: 'Reset Y-Axis maximum value to current data maximum value',
+    messages: {
+      success: 'Y-Axis Maximum value updated successfully.',
+      error: 'Invalid input. Please check the value.',
+    },
+    validation: {
+      positiveNumber: 'Value must be a positive number',
+    },
   },
   'group-filters': {
     title: 'Manage Groups',

--- a/src/components/LineChartComponents/LineChart.tsx
+++ b/src/components/LineChartComponents/LineChart.tsx
@@ -72,7 +72,7 @@ interface LineChartProps {
   horizontalYAxisThreshold?: number;
 
   /** Optional maximum value from the chart data. Can be used to set custom Y-axis limits. */
-  maxDataValue?: number;
+  yAxisMaxValue?: number;
 }
 /**
  * React Component to render the Linechart Section
@@ -91,7 +91,7 @@ export default function LineChart({
   yAxisLabel,
   localization,
   horizontalYAxisThreshold = undefined,
-  maxDataValue,
+  yAxisMaxValue,
 }: LineChartProps): JSX.Element {
   const {t: defaultT, i18n} = useTranslation();
 
@@ -174,8 +174,8 @@ export default function LineChart({
     }
     return {
       renderer: AxisRendererY.new(root, {}),
-
       strictMinMax: true,
+
       // Fix lower end to 0
       min: 0,
 
@@ -189,12 +189,12 @@ export default function LineChart({
   useLayoutEffect(() => {
     if (!yAxis || !root || !chart || chart.isDisposed() || root.isDisposed()) return;
 
-    if (maxDataValue != null) {
-      yAxis.set('max', maxDataValue);
+    if (yAxisMaxValue != null) {
+      yAxis.set('max', yAxisMaxValue);
     } else {
       yAxis.set('max', undefined);
     }
-  }, [yAxis, maxDataValue, root, chart]);
+  }, [yAxis, yAxisMaxValue, root, chart]);
 
   // Effect to add cursor to chart
   useLayoutEffect(() => {

--- a/src/components/LineChartComponents/LineChart.tsx
+++ b/src/components/LineChartComponents/LineChart.tsx
@@ -178,6 +178,7 @@ export default function LineChart({
       strictMinMax: true,
       // Fix lower end to 0
       min: 0,
+
       // Add tooltip instance so cursor can display value
 
       max: maxDataValue ?? undefined,
@@ -187,6 +188,17 @@ export default function LineChart({
   }, [root, chart, maxDataValue]);
 
   const yAxis = useValueAxis(root, chart, yAxisSettings);
+
+  // max value y-axis change so that its not recreated everytime max value changes
+  useLayoutEffect(() => {
+    if (!yAxis || !root || !chart || chart.isDisposed() || root.isDisposed()) return;
+
+    if (maxDataValue != null) {
+      yAxis.set('max', maxDataValue);
+    } else {
+      yAxis.set('max', undefined);
+    }
+  }, [yAxis, maxDataValue, root, chart]);
 
   // Effect to add cursor to chart
   useLayoutEffect(() => {

--- a/src/components/LineChartComponents/LineChart.tsx
+++ b/src/components/LineChartComponents/LineChart.tsx
@@ -169,17 +169,18 @@ export default function LineChart({
   );
 
   const yAxisSettings = useMemo(() => {
-    if (!root || !chart) {
+    if (!root || !chart || chart.isDisposed() || root.isDisposed()) {
       return null;
     }
     return {
       renderer: AxisRendererY.new(root, {}),
+
+      strictMinMax: true,
       // Fix lower end to 0
       min: 0,
       // Add tooltip instance so cursor can display value
 
-      //here we can set the max value of the y-axis, if we want to limit the y-axis to a certain value
-      max: maxDataValue,
+      max: maxDataValue ?? undefined,
 
       tooltip: Tooltip.new(root, {}),
     };

--- a/src/components/LineChartComponents/LineChart.tsx
+++ b/src/components/LineChartComponents/LineChart.tsx
@@ -179,13 +179,9 @@ export default function LineChart({
       // Fix lower end to 0
       min: 0,
 
-      // Add tooltip instance so cursor can display value
-
-      max: maxDataValue ?? undefined,
-
       tooltip: Tooltip.new(root, {}),
     };
-  }, [root, chart, maxDataValue]);
+  }, [root, chart]);
 
   const yAxis = useValueAxis(root, chart, yAxisSettings);
 

--- a/src/components/LineChartComponents/LineChart.tsx
+++ b/src/components/LineChartComponents/LineChart.tsx
@@ -70,6 +70,9 @@ interface LineChartProps {
 
   /** Optional horizontal limit for the Y-axis. Defaults to 0. */
   horizontalYAxisThreshold?: number;
+
+  /** Optional maximum value from the chart data. Can be used to set custom Y-axis limits. */
+  maxDataValue?: number;
 }
 /**
  * React Component to render the Linechart Section
@@ -88,6 +91,7 @@ export default function LineChart({
   yAxisLabel,
   localization,
   horizontalYAxisThreshold = undefined,
+  maxDataValue,
 }: LineChartProps): JSX.Element {
   const {t: defaultT, i18n} = useTranslation();
 
@@ -173,9 +177,13 @@ export default function LineChart({
       // Fix lower end to 0
       min: 0,
       // Add tooltip instance so cursor can display value
+
+      //here we can set the max value of the y-axis, if we want to limit the y-axis to a certain value
+      max: maxDataValue,
+
       tooltip: Tooltip.new(root, {}),
     };
-  }, [root, chart]);
+  }, [root, chart, maxDataValue]);
 
   const yAxis = useValueAxis(root, chart, yAxisSettings);
 

--- a/src/components/LineChartComponents/LineChart.tsx
+++ b/src/components/LineChartComponents/LineChart.tsx
@@ -178,7 +178,7 @@ export default function LineChart({
 
       // Fix lower end to 0
       min: 0,
-
+      // Add tooltip instance so cursor can display value
       tooltip: Tooltip.new(root, {}),
     };
   }, [root, chart]);

--- a/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
@@ -93,7 +93,6 @@ export default function LineChartSettings({
   const {i18n} = useTranslation();
   const {formatNumber} = NumberFormatter(i18n.language, 1, 0);
 
-
   const [currentView, setCurrentView] = useState<SettingsView>('settingsMenu');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [showPopover, setShowPopover] = useState<boolean>(false);
@@ -107,8 +106,9 @@ export default function LineChartSettings({
 
   /**
    * The settings menu for the line chart. Each item in the menu has a label, a view, and an icon.
+   * kind: 'inline' - the item is displayed inline
+   * kind: 'navigate' - the item is displayed as a button that navigates to a new view
    */
-
   const settingsMenu: SettingsItem[] = [
     {
       kind: 'inline',

--- a/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
 // SPDX-License-Identifier: Apache-2.0
 
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import SettingsIcon from '@mui/icons-material/Settings';
 import Popover from '@mui/material/Popover';
 import Typography from '@mui/material/Typography';
@@ -18,6 +18,7 @@ import type {District} from 'types/district';
 import {useTranslation} from 'react-i18next';
 import ThresholdSettings from './ThresholdSettings/ThresholdSettings';
 import YAxisValueSettings from './yAxisValueSettings/yAxisValueSettings';
+import {NumberFormatter} from 'util/hooks';
 
 /**
  * The different views that can be displayed in the settings popover.
@@ -75,6 +76,7 @@ export default function LineChartSettings({
   updateYAxisMaxValue,
 }: LineChartSettingsProps) {
   const {t: tSettings} = useTranslation('settings');
+  const {i18n} = useTranslation();
 
   /**
    * The settings menu for the line chart. Each item in the menu has a label, a view, and an icon.
@@ -102,6 +104,14 @@ export default function LineChartSettings({
   const [currentView, setCurrentView] = useState<SettingsView>('settingsMenu');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [showPopover, setShowPopover] = useState<boolean>(false);
+  const {formatNumber} = NumberFormatter(i18n.language, 1, 0);
+
+  const localization = useMemo(() => {
+    return {
+      formatNumber: formatNumber,
+      customLang: 'backend',
+    };
+  }, [formatNumber]);
 
   const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -229,6 +239,7 @@ export default function LineChartSettings({
               selectedCompartment={selectedCompartment}
               yAxisMaxValue={yAxisMaxValue}
               updateYAxisMaxValue={updateYAxisMaxValue}
+              localization={localization}
             />
           </Box>
         )}

--- a/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
@@ -12,7 +12,7 @@ import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import DataThresholdingIcon from '@mui/icons-material/DataThresholdingRounded';
-import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
 import type {Threshold} from 'types/threshold';
 import type {District} from 'types/district';
 import {useTranslation} from 'react-i18next';
@@ -26,14 +26,24 @@ import {NumberFormatter} from 'util/hooks';
  */
 type SettingsView = 'settingsMenu' | 'thresholdSettings' | 'yAxisMaxValueSettings';
 
-type SettingsMenu = {
-  [key: string]: {
-    label: string;
-    description: string;
-    view: string;
-    icon: JSX.Element;
-  };
+type NavigationItem = {
+  kind: 'navigate';
+  label?: string;
+  description: string;
+  icon: JSX.Element;
+  view: SettingsView; // 'horizontalThresholdSettings' | ...
 };
+
+type InlineItem = {
+  kind: 'inline';
+  label?: string;
+  description?: string;
+  icon?: JSX.Element;
+  element: JSX.Element; // the component you want to show inline
+};
+
+type SettingsItem = NavigationItem | InlineItem;
+
 export interface LineChartSettingsProps {
   /** The district to which the settings apply. */
   selectedDistrict: District;
@@ -54,7 +64,10 @@ export interface LineChartSettingsProps {
   updateThreshold: (newThreshold: Threshold) => void;
 
   /** The maximum value for the y-axis. */
-  yAxisMaxValue: number;
+  yAxisMaxValue: number | undefined;
+
+  /** The maximum value for the data. */
+  maxDataValue: number;
 
   /** The function to update the maximum value for the y-axis. */
   updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
@@ -73,38 +86,17 @@ export default function LineChartSettings({
   removeThreshold,
   updateThreshold,
   yAxisMaxValue,
+  maxDataValue,
   updateYAxisMaxValue,
 }: LineChartSettingsProps) {
   const {t: tSettings} = useTranslation('settings');
   const {i18n} = useTranslation();
+  const {formatNumber} = NumberFormatter(i18n.language, 1, 0);
 
-  /**
-   * The settings menu for the line chart. Each item in the menu has a label, a view, and an icon.
-   */
-
-  const settingsMenu: SettingsMenu = {
-    threshold: {
-      label: tSettings('manageThreshold'),
-      description: tSettings('manageThresholdDescription'),
-      view: 'thresholdSettings',
-      icon: (
-        <DataThresholdingIcon
-          sx={{backgroundColor: 'primary.main', color: 'white', padding: '4px', borderRadius: '10%'}}
-        />
-      ),
-    },
-    yAxisMaxValue: {
-      label: tSettings('yAxisMaxValue'),
-      description: tSettings('yAxisMaxValueDescription'),
-      view: 'yAxisMaxValueSettings',
-      icon: <HorizontalRuleIcon />,
-    },
-  };
 
   const [currentView, setCurrentView] = useState<SettingsView>('settingsMenu');
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [showPopover, setShowPopover] = useState<boolean>(false);
-  const {formatNumber} = NumberFormatter(i18n.language, 1, 0);
 
   const localization = useMemo(() => {
     return {
@@ -112,6 +104,35 @@ export default function LineChartSettings({
       customLang: 'backend',
     };
   }, [formatNumber]);
+
+  /**
+   * The settings menu for the line chart. Each item in the menu has a label, a view, and an icon.
+   */
+
+  const settingsMenu: SettingsItem[] = [
+    {
+      kind: 'inline',
+      label: tSettings('yAxisMaxValue'),
+      element: (
+        <Box sx={{display: 'flex', p: 2, alignItems: 'center'}}>
+          <ShowChartIcon sx={{bgcolor: 'primary.main', color: 'white', p: '4px', borderRadius: '10%'}} />
+          <YAxisValueSettings
+            yAxisMaxValue={yAxisMaxValue}
+            maxDataValue={maxDataValue}
+            updateYAxisMaxValue={updateYAxisMaxValue}
+            localization={localization}
+          />
+        </Box>
+      ),
+    },
+    {
+      kind: 'navigate',
+      label: tSettings('manageThreshold'),
+      description: tSettings('manageThresholdDescription'),
+      icon: <DataThresholdingIcon sx={{bgcolor: 'primary.main', color: 'white', p: '4px', borderRadius: '10%'}} />,
+      view: 'thresholdSettings',
+    },
+  ];
 
   const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -183,36 +204,33 @@ export default function LineChartSettings({
         {currentView === 'settingsMenu' && (
           <Box p={4} data-testid='main-settings-menu'>
             {renderHeader(tSettings('title'))}
-            {Object.entries(settingsMenu).map(([key, item]) => (
-              <Box key={key}>
-                <Divider sx={{marginY: 2}} variant='middle' />
-                <Button
-                  data-testid={`settings-menu-item-${key}`}
-                  onClick={() => handleNavigate(item.view as SettingsView)}
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    width: '100%',
-                    justifyContent: 'flex-start',
-                    alignContent: 'center',
-                  }}
-                >
-                  {item.icon}
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'flex-start',
-                      justifyContent: 'center',
-                      marginLeft: 4,
-                    }}
+            {settingsMenu.map((item, idx) => (
+              <Box key={idx}>
+                <Divider sx={{my: '10px'}} variant='middle' />
+                {item.kind === 'navigate' ? (
+                  <Button
+                    onClick={() => handleNavigate(item.view)}
+                    sx={{display: 'flex', width: '100%', justifyContent: 'flex-start'}}
                   >
-                    <Typography variant='h2'>{item.label}</Typography>
-                    <Typography variant='body1' sx={{textTransform: 'none', color: 'gray'}}>
-                      {item.description}
-                    </Typography>
-                  </Box>
-                </Button>
+                    {item.icon}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'flex-start',
+                        justifyContent: 'center',
+                        marginLeft: 4,
+                      }}
+                    >
+                      <Typography variant='h2'>{item.label}</Typography>
+                      <Typography variant='body1' sx={{textTransform: 'none', color: 'gray'}}>
+                        {item.description}
+                      </Typography>
+                    </Box>
+                  </Button>
+                ) : (
+                  <Box>{item.element}</Box>
+                )}
               </Box>
             ))}
           </Box>
@@ -228,18 +246,6 @@ export default function LineChartSettings({
               thresholds={thresholds}
               removeThreshold={removeThreshold}
               updateThreshold={updateThreshold}
-            />
-          </Box>
-        )}
-        {currentView === 'yAxisMaxValueSettings' && (
-          <Box p={4}>
-            {renderHeader(tSettings('yAxisMaxValue'))}
-            <YAxisValueSettings
-              selectedDistrict={selectedDistrict}
-              selectedCompartment={selectedCompartment}
-              yAxisMaxValue={yAxisMaxValue}
-              updateYAxisMaxValue={updateYAxisMaxValue}
-              localization={localization}
             />
           </Box>
         )}

--- a/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
@@ -12,16 +12,18 @@ import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import DataThresholdingIcon from '@mui/icons-material/DataThresholdingRounded';
+import HorizontalRuleIcon from '@mui/icons-material/HorizontalRule';
 import type {Threshold} from 'types/threshold';
 import type {District} from 'types/district';
 import {useTranslation} from 'react-i18next';
 import ThresholdSettings from './ThresholdSettings/ThresholdSettings';
+import YAxisValueSettings from './yAxisValueSettings/yAxisValueSettings';
 
 /**
  * The different views that can be displayed in the settings popover.
  * You can add more views here if you want to add more settings.
  */
-type SettingsView = 'settingsMenu' | 'thresholdSettings' | 'filters';
+type SettingsView = 'settingsMenu' | 'thresholdSettings' | 'yAxisMaxValueSettings';
 
 type SettingsMenu = {
   [key: string]: {
@@ -49,6 +51,12 @@ export interface LineChartSettingsProps {
 
   /** The function to update a horizontal threshold. */
   updateThreshold: (newThreshold: Threshold) => void;
+
+  /** The maximum value for the y-axis. */
+  yAxisMaxValue: number;
+
+  /** The function to update the maximum value for the y-axis. */
+  updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
 }
 
 /**
@@ -63,6 +71,8 @@ export default function LineChartSettings({
   thresholds,
   removeThreshold,
   updateThreshold,
+  yAxisMaxValue,
+  updateYAxisMaxValue,
 }: LineChartSettingsProps) {
   const {t: tSettings} = useTranslation('settings');
 
@@ -81,11 +91,12 @@ export default function LineChartSettings({
         />
       ),
     },
-    // filters: {
-    //   label: tSettings('manageGroups'),
-    //   view: 'filters',
-    //   icon: <HorizontalRuleIcon />,
-    // },
+    yAxisMaxValue: {
+      label: tSettings('yAxisMaxValue'),
+      description: tSettings('yAxisMaxValueDescription'),
+      view: 'yAxisMaxValueSettings',
+      icon: <HorizontalRuleIcon />,
+    },
   };
 
   const [currentView, setCurrentView] = useState<SettingsView>('settingsMenu');
@@ -207,6 +218,17 @@ export default function LineChartSettings({
               thresholds={thresholds}
               removeThreshold={removeThreshold}
               updateThreshold={updateThreshold}
+            />
+          </Box>
+        )}
+        {currentView === 'yAxisMaxValueSettings' && (
+          <Box p={4}>
+            {renderHeader(tSettings('yAxisMaxValue'))}
+            <YAxisValueSettings
+              selectedDistrict={selectedDistrict}
+              selectedCompartment={selectedCompartment}
+              yAxisMaxValue={yAxisMaxValue}
+              updateYAxisMaxValue={updateYAxisMaxValue}
             />
           </Box>
         )}

--- a/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/LineChartSettings.tsx
@@ -70,7 +70,7 @@ export interface LineChartSettingsProps {
   maxDataValue: number;
 
   /** The function to update the maximum value for the y-axis. */
-  updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
+  updateYAxisMaxValue: (newYAxisMaxValue: number | undefined) => void;
 }
 
 /**

--- a/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
 import Box from '@mui/material/Box';
+import {Localization} from 'types/localization';
 import {District} from 'types/district';
 import {TextField, useTheme} from '@mui/material';
 import IconButton from '@mui/material/IconButton';
@@ -11,13 +12,26 @@ interface YAxisValueSettingsProps {
   selectedCompartment: string;
   yAxisMaxValue: number;
   updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
+  localization: Localization;
 }
 
-export default function YAxisValueSettings({yAxisMaxValue, updateYAxisMaxValue}: YAxisValueSettingsProps) {
+export default function YAxisValueSettings({
+  yAxisMaxValue,
+  updateYAxisMaxValue,
+  localization = {
+    formatNumber: (value: number) => value.toString(),
+    customLang: 'global',
+    overrides: {},
+  },
+}: YAxisValueSettingsProps) {
   const theme = useTheme();
   const [localYAxisMaxValue, setLocalYAxisMaxValue] = useState<number | null>(yAxisMaxValue);
   const [, setEditingYAxisMaxValue] = useState<boolean>(false);
   const isValid = localYAxisMaxValue !== null && localYAxisMaxValue > 0;
+
+  function GetFormattedAndTranslatedValues(filteredValues: number): string {
+    return localization.formatNumber ? localization.formatNumber(filteredValues) : filteredValues.toString();
+  }
 
   return (
     <Box>
@@ -25,6 +39,7 @@ export default function YAxisValueSettings({yAxisMaxValue, updateYAxisMaxValue}:
         label='Y-Axis Max Value'
         id='y-axis-max-value'
         value={localYAxisMaxValue}
+        placeholder={GetFormattedAndTranslatedValues(yAxisMaxValue)}
         error={!isValid}
         onChange={(e) => {
           const value = e.target.value === '' ? null : Number(e.target.value);

--- a/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
@@ -1,0 +1,69 @@
+import React, {useState} from 'react';
+import Box from '@mui/material/Box';
+import {District} from 'types/district';
+import {TextField, useTheme} from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+import CheckIcon from '@mui/icons-material/Check';
+import CancelIcon from '@mui/icons-material/Cancel';
+
+interface YAxisValueSettingsProps {
+  selectedDistrict: District;
+  selectedCompartment: string;
+  yAxisMaxValue: number;
+  updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
+}
+
+export default function YAxisValueSettings({yAxisMaxValue, updateYAxisMaxValue}: YAxisValueSettingsProps) {
+  const theme = useTheme();
+  const [localYAxisMaxValue, setLocalYAxisMaxValue] = useState<number | null>(yAxisMaxValue);
+  const [, setEditingYAxisMaxValue] = useState<boolean>(false);
+  const isValid = localYAxisMaxValue !== null && localYAxisMaxValue > 0;
+
+  return (
+    <Box>
+      <TextField
+        label='Y-Axis Max Value'
+        id='y-axis-max-value'
+        value={localYAxisMaxValue}
+        error={!isValid}
+        onChange={(e) => {
+          const value = e.target.value === '' ? null : Number(e.target.value);
+          setLocalYAxisMaxValue(value);
+        }}
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 1,
+        }}
+      >
+        <IconButton
+          aria-label='add or edit Horizontal Threshold onto selected compartment and district'
+          data-testid='save-threshold'
+          onClick={() => {
+            if (localYAxisMaxValue === null || localYAxisMaxValue < 0) return;
+            console.log('localYAxisMaxValue', localYAxisMaxValue);
+            updateYAxisMaxValue(localYAxisMaxValue);
+            setEditingYAxisMaxValue(false);
+            console.log('UPDATE Y-AXIS MAX VALUE');
+          }}
+          disabled={!isValid}
+          sx={{color: theme.palette.success.main}}
+        >
+          <CheckIcon />
+        </IconButton>
+        <IconButton
+          aria-label='cancel editing threshold'
+          data-testid='cancel-threshold'
+          onClick={() => {
+            setEditingYAxisMaxValue(false);
+          }}
+          sx={{color: theme.palette.error.main}}
+        >
+          <CancelIcon />
+        </IconButton>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
@@ -26,7 +26,7 @@ interface YAxisValueSettingsProps {
   maxDataValue: number;
 
   /** The function to update the Y-axis maximum value */
-  updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
+  updateYAxisMaxValue: (newYAxisMaxValue: number | undefined) => void;
 
   /** The localization object */
   localization: Localization;
@@ -98,7 +98,7 @@ export default function YAxisValueSettings({
   };
 
   const handleReset = () => {
-    updateYAxisMaxValue(maxDataValue);
+    updateYAxisMaxValue(undefined);
     setLocalYAxisMaxValue(maxDataValue);
   };
 

--- a/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
@@ -4,18 +4,31 @@
 import React, {useState} from 'react';
 import Box from '@mui/material/Box';
 import {Localization} from 'types/localization';
-import {TextField, Typography, useTheme} from '@mui/material';
+import {Button, useTheme} from '@mui/material';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Snackbar from '@mui/material/Snackbar';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import CheckIcon from '@mui/icons-material/Check';
 import CancelIcon from '@mui/icons-material/Cancel';
 import EditIcon from '@mui/icons-material/Edit';
 import RefreshIcon from '@mui/icons-material/Refresh';
-
+import Divider from '@mui/material/Divider';
+import Portal from '@mui/material/Portal';
+import Alert from '@mui/material/Alert';
+import {useTranslation} from 'react-i18next';
 interface YAxisValueSettingsProps {
+  /** The maximum value for the Y-axis */
   yAxisMaxValue: number | undefined;
+
+  /** The actual maximum value of the currently displayed data on the chart*/
   maxDataValue: number;
+
+  /** The function to update the Y-axis maximum value */
   updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
+
+  /** The localization object */
   localization: Localization;
 }
 
@@ -30,20 +43,53 @@ export default function YAxisValueSettings({
   },
 }: YAxisValueSettingsProps) {
   const theme = useTheme();
+  const {t} = useTranslation('settings');
   const [localYAxisMaxValue, setLocalYAxisMaxValue] = useState<number | null>(yAxisMaxValue ?? maxDataValue);
   const [editing, setEditing] = useState<boolean>(false);
-  const isValid = localYAxisMaxValue !== null && localYAxisMaxValue > 0;
+  const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false);
+  const [snackbarMessage, setSnackbarMessage] = useState<string>('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'info' | 'warning' | 'error'>('info');
+  const [errors, setErrors] = useState<string[]>([]);
 
   const getFormattedAndTranslatedValues = (filteredValues: number): string => {
     return localization.formatNumber ? localization.formatNumber(filteredValues) : filteredValues.toString();
   };
 
-  const handleSave = () => {
-    if (localYAxisMaxValue === null || localYAxisMaxValue < 0) return;
-    console.log('localYAxisMaxValue', localYAxisMaxValue);
-    updateYAxisMaxValue(localYAxisMaxValue);
-    setEditing(false);
-    console.log('UPDATE Y-AXIS MAX VALUE');
+  const validateInput = (newYValue: number | null): boolean => {
+    const errors: string[] = [];
+    if (newYValue === null || newYValue < 0) {
+      errors.push(t('y-axis-settings.validation.positiveNumber'));
+    }
+
+    setErrors(errors);
+    return errors.length === 0;
+  };
+
+  const handleSnackbarOpen = (message: string, severity: 'success' | 'info' | 'warning' | 'error' = 'info') => {
+    setSnackbarMessage(message);
+    setSnackbarSeverity(severity);
+    setSnackbarOpen(true);
+  };
+
+  const handleSave = (newYValue: number | null) => {
+    if (newYValue === null) {
+      updateYAxisMaxValue(maxDataValue);
+      setLocalYAxisMaxValue(maxDataValue);
+      setEditing(false);
+      return;
+    }
+
+    if (validateInput(newYValue)) {
+      if (newYValue === yAxisMaxValue) {
+        setEditing(false);
+        return;
+      }
+
+      updateYAxisMaxValue(newYValue);
+      setLocalYAxisMaxValue(newYValue);
+      setEditing(false);
+      handleSnackbarOpen(t('y-axis-settings.messages.success'), 'success');
+    }
   };
 
   const handleCancel = () => {
@@ -57,33 +103,74 @@ export default function YAxisValueSettings({
   };
 
   return (
-    <Box sx={{width: '100%', marginLeft: 4}}>
-      {editing ? (
-        <Box
+    <Box
+      sx={{
+        width: '100%',
+        marginLeft: 4,
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 4,
+      }}
+    >
+      <Portal>
+        <Snackbar
+          open={snackbarOpen}
+          autoHideDuration={4000}
+          onClose={() => setSnackbarOpen(false)}
+          anchorOrigin={{vertical: 'bottom', horizontal: 'left'}}
+        >
+          <Alert severity={snackbarSeverity}>{snackbarMessage}</Alert>
+        </Snackbar>
+      </Portal>
+      <Box sx={{display: 'flex', flexDirection: 'row', alignItems: 'center', gap: 2}}>
+        <Typography
+          variant='h2'
           sx={{
-            display: 'flex',
-            flexDirection: 'row',
-            gap: 1,
-            alignItems: 'center',
-            justifyContent: 'space-between',
+            color: theme.palette.primary.main,
+            textTransform: 'uppercase',
+            paddingRight: 2,
           }}
         >
-          <Typography variant='h2' sx={{color: 'black'}}>
-            Y-Axis Maximum
-          </Typography>
-          <Box sx={{display: 'flex', flexDirection: 'row', gap: 1, alignItems: 'center'}}>
+          {t('y-axis-settings.title')}
+        </Typography>
+      </Box>
+      <Divider orientation='vertical' flexItem />
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 1,
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        {editing ? (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              gap: 3,
+              alignItems: 'center',
+              width: '100%',
+              justifyContent: 'space-between',
+            }}
+          >
             <TextField
-              label='Y-Axis Max Value'
               id='y-axis-max-value'
               value={localYAxisMaxValue}
               placeholder={getFormattedAndTranslatedValues(yAxisMaxValue ?? maxDataValue)}
-              error={!isValid}
+              error={errors.length > 0}
+              helperText={errors.join(', ')}
               onChange={(e) => {
+                setErrors([]);
                 const value = e.target.value === '' ? null : Number(e.target.value);
                 setLocalYAxisMaxValue(value);
               }}
               size='small'
               variant='outlined'
+              sx={{width: '100%'}}
             />
             <Box
               sx={{
@@ -97,9 +184,9 @@ export default function YAxisValueSettings({
                 data-testid='save-threshold'
                 onClick={(e) => {
                   e.stopPropagation();
-                  handleSave();
+                  handleSave(localYAxisMaxValue);
                 }}
-                disabled={!isValid}
+                disabled={errors.length > 0}
                 sx={{color: theme.palette.success.main}}
               >
                 <CheckIcon />
@@ -117,49 +204,54 @@ export default function YAxisValueSettings({
               </IconButton>
             </Box>
           </Box>
-        </Box>
-      ) : (
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'flex-start'}}>
-            <Typography variant='h2' sx={{color: 'black'}}>
-              Y-Axis Maximum
-            </Typography>
-            <Typography variant='caption' sx={{color: 'gray'}}>
-              Global maximum value of the y-axis.
-            </Typography>
-          </Box>
-          <Box sx={{display: 'flex', flexDirection: 'row', gap: 2, alignItems: 'center'}}>
-            <Typography variant='h2' sx={{marginRight: '1rem'}}>
-              {getFormattedAndTranslatedValues(yAxisMaxValue ?? maxDataValue)}
-            </Typography>
+        ) : (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              gap: 3,
+              alignItems: 'center',
+              width: '100%',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Button
+              variant='text'
+              onClick={() => setEditing(true)}
+              sx={{
+                cursor: 'text',
+              }}
+            >
+              <Typography
+                variant='body1'
+                sx={{
+                  color: 'black',
+                }}
+              >
+                {getFormattedAndTranslatedValues(yAxisMaxValue ?? maxDataValue)}
+              </Typography>
+            </Button>
             <Box sx={{display: 'flex', flexDirection: 'row', gap: 1, alignItems: 'center'}}>
-              <Tooltip title='Edit Y-Axis Maximum'>
+              <Tooltip title={t('y-axis-settings.editTooltip')}>
                 <IconButton onClick={() => setEditing(true)}>
                   <EditIcon />
                 </IconButton>
               </Tooltip>
-              <Tooltip title='Reset to current data maximum value'>
+              <Tooltip title={t('y-axis-settings.resetTooltip')}>
                 <IconButton
                   onClick={(e) => {
                     e.stopPropagation();
                     handleReset();
                   }}
+                  disabled={localYAxisMaxValue === maxDataValue}
                 >
                   <RefreshIcon />
                 </IconButton>
               </Tooltip>
             </Box>
           </Box>
-        </Box>
-      )}
+        )}
+      </Box>
     </Box>
   );
 }

--- a/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
+++ b/src/components/LineChartComponents/LineChartSettingsComponents/yAxisValueSettings/yAxisValueSettings.tsx
@@ -1,22 +1,27 @@
+// SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
+// SPDX-License-Identifier: Apache-2.0
+
 import React, {useState} from 'react';
 import Box from '@mui/material/Box';
 import {Localization} from 'types/localization';
-import {District} from 'types/district';
-import {TextField, useTheme} from '@mui/material';
+import {TextField, Typography, useTheme} from '@mui/material';
+import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import CheckIcon from '@mui/icons-material/Check';
 import CancelIcon from '@mui/icons-material/Cancel';
+import EditIcon from '@mui/icons-material/Edit';
+import RefreshIcon from '@mui/icons-material/Refresh';
 
 interface YAxisValueSettingsProps {
-  selectedDistrict: District;
-  selectedCompartment: string;
-  yAxisMaxValue: number;
+  yAxisMaxValue: number | undefined;
+  maxDataValue: number;
   updateYAxisMaxValue: (newYAxisMaxValue: number) => void;
   localization: Localization;
 }
 
 export default function YAxisValueSettings({
   yAxisMaxValue,
+  maxDataValue,
   updateYAxisMaxValue,
   localization = {
     formatNumber: (value: number) => value.toString(),
@@ -25,60 +30,136 @@ export default function YAxisValueSettings({
   },
 }: YAxisValueSettingsProps) {
   const theme = useTheme();
-  const [localYAxisMaxValue, setLocalYAxisMaxValue] = useState<number | null>(yAxisMaxValue);
-  const [, setEditingYAxisMaxValue] = useState<boolean>(false);
+  const [localYAxisMaxValue, setLocalYAxisMaxValue] = useState<number | null>(yAxisMaxValue ?? maxDataValue);
+  const [editing, setEditing] = useState<boolean>(false);
   const isValid = localYAxisMaxValue !== null && localYAxisMaxValue > 0;
 
-  function GetFormattedAndTranslatedValues(filteredValues: number): string {
+  const getFormattedAndTranslatedValues = (filteredValues: number): string => {
     return localization.formatNumber ? localization.formatNumber(filteredValues) : filteredValues.toString();
-  }
+  };
+
+  const handleSave = () => {
+    if (localYAxisMaxValue === null || localYAxisMaxValue < 0) return;
+    console.log('localYAxisMaxValue', localYAxisMaxValue);
+    updateYAxisMaxValue(localYAxisMaxValue);
+    setEditing(false);
+    console.log('UPDATE Y-AXIS MAX VALUE');
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+    setLocalYAxisMaxValue(yAxisMaxValue ?? maxDataValue);
+  };
+
+  const handleReset = () => {
+    updateYAxisMaxValue(maxDataValue);
+    setLocalYAxisMaxValue(maxDataValue);
+  };
 
   return (
-    <Box>
-      <TextField
-        label='Y-Axis Max Value'
-        id='y-axis-max-value'
-        value={localYAxisMaxValue}
-        placeholder={GetFormattedAndTranslatedValues(yAxisMaxValue)}
-        error={!isValid}
-        onChange={(e) => {
-          const value = e.target.value === '' ? null : Number(e.target.value);
-          setLocalYAxisMaxValue(value);
-        }}
-      />
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          gap: 1,
-        }}
-      >
-        <IconButton
-          aria-label='add or edit Horizontal Threshold onto selected compartment and district'
-          data-testid='save-threshold'
-          onClick={() => {
-            if (localYAxisMaxValue === null || localYAxisMaxValue < 0) return;
-            console.log('localYAxisMaxValue', localYAxisMaxValue);
-            updateYAxisMaxValue(localYAxisMaxValue);
-            setEditingYAxisMaxValue(false);
-            console.log('UPDATE Y-AXIS MAX VALUE');
+    <Box sx={{width: '100%', marginLeft: 4}}>
+      {editing ? (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+            gap: 1,
+            alignItems: 'center',
+            justifyContent: 'space-between',
           }}
-          disabled={!isValid}
-          sx={{color: theme.palette.success.main}}
         >
-          <CheckIcon />
-        </IconButton>
-        <IconButton
-          aria-label='cancel editing threshold'
-          data-testid='cancel-threshold'
-          onClick={() => {
-            setEditingYAxisMaxValue(false);
+          <Typography variant='h2' sx={{color: 'black'}}>
+            Y-Axis Maximum
+          </Typography>
+          <Box sx={{display: 'flex', flexDirection: 'row', gap: 1, alignItems: 'center'}}>
+            <TextField
+              label='Y-Axis Max Value'
+              id='y-axis-max-value'
+              value={localYAxisMaxValue}
+              placeholder={getFormattedAndTranslatedValues(yAxisMaxValue ?? maxDataValue)}
+              error={!isValid}
+              onChange={(e) => {
+                const value = e.target.value === '' ? null : Number(e.target.value);
+                setLocalYAxisMaxValue(value);
+              }}
+              size='small'
+              variant='outlined'
+            />
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                gap: 1,
+              }}
+            >
+              <IconButton
+                aria-label='add or edit Horizontal Threshold onto selected compartment and district'
+                data-testid='save-threshold'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSave();
+                }}
+                disabled={!isValid}
+                sx={{color: theme.palette.success.main}}
+              >
+                <CheckIcon />
+              </IconButton>
+              <IconButton
+                aria-label='cancel editing threshold'
+                data-testid='cancel-threshold'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCancel();
+                }}
+                sx={{color: theme.palette.error.main}}
+              >
+                <CancelIcon />
+              </IconButton>
+            </Box>
+          </Box>
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'row',
+
+            justifyContent: 'space-between',
+            alignItems: 'center',
           }}
-          sx={{color: theme.palette.error.main}}
         >
-          <CancelIcon />
-        </IconButton>
-      </Box>
+          <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'flex-start'}}>
+            <Typography variant='h2' sx={{color: 'black'}}>
+              Y-Axis Maximum
+            </Typography>
+            <Typography variant='caption' sx={{color: 'gray'}}>
+              Global maximum value of the y-axis.
+            </Typography>
+          </Box>
+          <Box sx={{display: 'flex', flexDirection: 'row', gap: 2, alignItems: 'center'}}>
+            <Typography variant='h2' sx={{marginRight: '1rem'}}>
+              {getFormattedAndTranslatedValues(yAxisMaxValue ?? maxDataValue)}
+            </Typography>
+            <Box sx={{display: 'flex', flexDirection: 'row', gap: 1, alignItems: 'center'}}>
+              <Tooltip title='Edit Y-Axis Maximum'>
+                <IconButton onClick={() => setEditing(true)}>
+                  <EditIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title='Reset to current data maximum value'>
+                <IconButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleReset();
+                  }}
+                >
+                  <RefreshIcon />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          </Box>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/components/LineChartContainer.tsx
+++ b/src/components/LineChartContainer.tsx
@@ -179,7 +179,7 @@ export default function LineChartContainer() {
       });
     });
 
-    return maxValue;
+    return Math.ceil(maxValue);
   }, [mappedLineChartData]);
 
   // Set reference day in store
@@ -220,7 +220,7 @@ export default function LineChartContainer() {
             })
           )
         }
-        yAxisMaxValue={yAxisMaxValue[`${selectedDistrict.nuts}-${selectedCompartment}`]}
+        yAxisMaxValue={yAxisMaxValue[`${selectedDistrict.nuts}-${selectedCompartment}`] ?? maxDataValue}
         updateYAxisMaxValue={(newYAxisMaxValue: number) =>
           dispatch(
             setYAxisMaxValue({

--- a/src/components/LineChartContainer.tsx
+++ b/src/components/LineChartContainer.tsx
@@ -13,8 +13,11 @@ import {useTranslation} from 'react-i18next';
 import {LineChartData} from 'types/lineChart';
 import {InfectionData} from 'store/services/APITypes';
 import {DataContext} from 'context/SelectedDataContext';
-import {updateHorizontalYAxisThreshold, removeHorizontalYAxisThreshold} from 'store/UserPreferenceSlice';
-
+import {
+  updateHorizontalYAxisThreshold,
+  removeHorizontalYAxisThreshold,
+  setYAxisMaxValue,
+} from 'store/UserPreferenceSlice';
 export default function LineChartContainer() {
   const {t: tBackend, i18n: i18nBackend} = useTranslation('backend');
   const theme = useTheme();
@@ -28,6 +31,7 @@ export default function LineChartContainer() {
   const selectedDistrict = useAppSelector((state) => state.dataSelection.district);
   const selectedDate = useAppSelector((state) => state.dataSelection.date);
   const thresholds = useAppSelector((state) => state.userPreference.horizontalYAxisThresholds ?? {});
+  const yAxisMaxValue = useAppSelector((state) => state.userPreference.yAxisMaxValue ?? {});
   const referenceDay = useAppSelector((state) => state.dataSelection.simulationStart);
   const minDate = useAppSelector((state) => state.dataSelection.minDate);
   const maxDate = useAppSelector((state) => state.dataSelection.maxDate);
@@ -200,7 +204,7 @@ export default function LineChartContainer() {
         referenceDay={referenceDay}
         yAxisLabel={yAxisLabel}
         horizontalYAxisThreshold={thresholds[`${selectedDistrict.nuts}-${selectedCompartment}`]?.threshold}
-        maxDataValue={maxDataValue}
+        maxDataValue={yAxisMaxValue[`${selectedDistrict.nuts}-${selectedCompartment}`] ?? undefined}
       />
       <LineChartSettings
         selectedDistrict={selectedDistrict}
@@ -213,6 +217,15 @@ export default function LineChartContainer() {
             updateHorizontalYAxisThreshold({
               key: `${newThreshold.district.nuts}-${newThreshold.compartment}`,
               threshold: newThreshold,
+            })
+          )
+        }
+        yAxisMaxValue={yAxisMaxValue[`${selectedDistrict.nuts}-${selectedCompartment}`]}
+        updateYAxisMaxValue={(newYAxisMaxValue: number) =>
+          dispatch(
+            setYAxisMaxValue({
+              key: `${selectedDistrict.nuts}-${selectedCompartment}`,
+              value: newYAxisMaxValue,
             })
           )
         }

--- a/src/components/LineChartContainer.tsx
+++ b/src/components/LineChartContainer.tsx
@@ -223,7 +223,7 @@ export default function LineChartContainer() {
         }
         yAxisMaxValue={yAxisMaxValue}
         maxDataValue={maxDataValue}
-        updateYAxisMaxValue={(newYAxisMaxValue: number) => dispatch(setYAxisMaxValue(newYAxisMaxValue))}
+        updateYAxisMaxValue={(newYAxisMaxValue: number | undefined) => dispatch(setYAxisMaxValue(newYAxisMaxValue))}
       />
     </LoadingContainer>
   );

--- a/src/components/LineChartContainer.tsx
+++ b/src/components/LineChartContainer.tsx
@@ -31,7 +31,7 @@ export default function LineChartContainer() {
   const selectedDistrict = useAppSelector((state) => state.dataSelection.district);
   const selectedDate = useAppSelector((state) => state.dataSelection.date);
   const thresholds = useAppSelector((state) => state.userPreference.horizontalYAxisThresholds ?? {});
-  const yAxisMaxValue = useAppSelector((state) => state.userPreference.yAxisMaxValue ?? {});
+  const yAxisMaxValue = useAppSelector((state) => state.userPreference.yAxisMaxValue ?? undefined);
   const referenceDay = useAppSelector((state) => state.dataSelection.simulationStart);
   const minDate = useAppSelector((state) => state.dataSelection.minDate);
   const maxDate = useAppSelector((state) => state.dataSelection.maxDate);
@@ -204,8 +204,9 @@ export default function LineChartContainer() {
         referenceDay={referenceDay}
         yAxisLabel={yAxisLabel}
         horizontalYAxisThreshold={thresholds[`${selectedDistrict.nuts}-${selectedCompartment}`]?.threshold}
-        maxDataValue={yAxisMaxValue[`${selectedDistrict.nuts}-${selectedCompartment}`] ?? undefined}
+        yAxisMaxValue={yAxisMaxValue ?? maxDataValue}
       />
+
       <LineChartSettings
         selectedDistrict={selectedDistrict}
         selectedCompartment={selectedCompartment ?? ''}
@@ -220,15 +221,9 @@ export default function LineChartContainer() {
             })
           )
         }
-        yAxisMaxValue={yAxisMaxValue[`${selectedDistrict.nuts}-${selectedCompartment}`] ?? maxDataValue}
-        updateYAxisMaxValue={(newYAxisMaxValue: number) =>
-          dispatch(
-            setYAxisMaxValue({
-              key: `${selectedDistrict.nuts}-${selectedCompartment}`,
-              value: newYAxisMaxValue,
-            })
-          )
-        }
+        yAxisMaxValue={yAxisMaxValue}
+        maxDataValue={maxDataValue}
+        updateYAxisMaxValue={(newYAxisMaxValue: number) => dispatch(setYAxisMaxValue(newYAxisMaxValue))}
       />
     </LoadingContainer>
   );

--- a/src/components/LineChartContainer.tsx
+++ b/src/components/LineChartContainer.tsx
@@ -153,6 +153,31 @@ export default function LineChartContainer() {
     });
   }, [groupFilterLineChartData, groupFilters, lineChartData, scenarios, scenariosState, selectedScenario]);
 
+  // Calculate maximum value from chart data
+  const maxDataValue = useMemo(() => {
+    if (!mappedLineChartData || mappedLineChartData.length === 0) {
+      return 0;
+    }
+
+    let maxValue = 0;
+
+    mappedLineChartData.forEach((serie) => {
+      serie.values.forEach((entry) => {
+        // Check main value
+        if (entry.value > maxValue) {
+          maxValue = entry.value;
+        }
+
+        // Check openValue if it exists (for percentile bands)
+        if (entry.openValue && entry.openValue > maxValue) {
+          maxValue = entry.openValue;
+        }
+      });
+    });
+
+    return maxValue;
+  }, [mappedLineChartData]);
+
   // Set reference day in store
   useEffect(() => {
     dispatch(setReferenceDayBottom(referenceDayBottomPosition));
@@ -175,6 +200,7 @@ export default function LineChartContainer() {
         referenceDay={referenceDay}
         yAxisLabel={yAxisLabel}
         horizontalYAxisThreshold={thresholds[`${selectedDistrict.nuts}-${selectedCompartment}`]?.threshold}
+        maxDataValue={maxDataValue}
       />
       <LineChartSettings
         selectedDistrict={selectedDistrict}

--- a/src/store/UserPreferenceSlice.ts
+++ b/src/store/UserPreferenceSlice.ts
@@ -10,7 +10,7 @@ export interface UserPreference {
   selectedTab?: string;
   isInitialVisit: boolean;
   horizontalYAxisThresholds?: Record<string, Threshold>;
-  yAxisMaxValue?: number;
+  yAxisMaxValue?: number | undefined;
   scenarioColors: Record<string, string[]>;
 }
 
@@ -84,7 +84,7 @@ export const UserPreferenceSlice = createSlice({
       delete state.horizontalYAxisThresholds[action.payload];
     },
     /** Set the maximum value for the Y-axis */
-    setYAxisMaxValue(state, action: PayloadAction<number>) {
+    setYAxisMaxValue(state, action: PayloadAction<number | undefined>) {
       state.yAxisMaxValue = action.payload;
     },
   },

--- a/src/store/UserPreferenceSlice.ts
+++ b/src/store/UserPreferenceSlice.ts
@@ -10,7 +10,7 @@ export interface UserPreference {
   selectedTab?: string;
   isInitialVisit: boolean;
   horizontalYAxisThresholds?: Record<string, Threshold>;
-  yAxisMaxValue?: Record<string, number>;
+  yAxisMaxValue?: number;
   scenarioColors: Record<string, string[]>;
 }
 
@@ -27,7 +27,7 @@ const initialState: UserPreference = {
   selectedTab: '1',
   isInitialVisit: true,
   horizontalYAxisThresholds: {},
-  yAxisMaxValue: {},
+  yAxisMaxValue: undefined,
   scenarioColors: {},
 };
 
@@ -84,14 +84,8 @@ export const UserPreferenceSlice = createSlice({
       delete state.horizontalYAxisThresholds[action.payload];
     },
     /** Set the maximum value for the Y-axis */
-    setYAxisMaxValue(state, action: PayloadAction<{key: string; value: number}>) {
-      if (!state.yAxisMaxValue) {
-        state.yAxisMaxValue = {};
-      }
-      state.yAxisMaxValue = {
-        ...state.yAxisMaxValue,
-        [action.payload.key]: action.payload.value,
-      };
+    setYAxisMaxValue(state, action: PayloadAction<number>) {
+      state.yAxisMaxValue = action.payload;
     },
   },
 });

--- a/src/store/UserPreferenceSlice.ts
+++ b/src/store/UserPreferenceSlice.ts
@@ -10,6 +10,7 @@ export interface UserPreference {
   selectedTab?: string;
   isInitialVisit: boolean;
   horizontalYAxisThresholds?: Record<string, Threshold>;
+  yAxisMaxValue?: Record<string, number>;
   scenarioColors: Record<string, string[]>;
 }
 
@@ -26,6 +27,7 @@ const initialState: UserPreference = {
   selectedTab: '1',
   isInitialVisit: true,
   horizontalYAxisThresholds: {},
+  yAxisMaxValue: {},
   scenarioColors: {},
 };
 
@@ -81,6 +83,16 @@ export const UserPreferenceSlice = createSlice({
       }
       delete state.horizontalYAxisThresholds[action.payload];
     },
+    /** Set the maximum value for the Y-axis */
+    setYAxisMaxValue(state, action: PayloadAction<{key: string; value: number}>) {
+      if (!state.yAxisMaxValue) {
+        state.yAxisMaxValue = {};
+      }
+      state.yAxisMaxValue = {
+        ...state.yAxisMaxValue,
+        [action.payload.key]: action.payload.value,
+      };
+    },
   },
 });
 
@@ -92,6 +104,7 @@ export const {
   updateHorizontalYAxisThreshold,
   removeHorizontalYAxisThreshold,
   setScenarioColors,
+  setYAxisMaxValue,
 } = UserPreferenceSlice.actions;
 
 export default UserPreferenceSlice.reducer;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

This pull request adds a feature to make the maximum value of the y-axis dynamic. The user can set the value through the user input, and the initial value will be displayed based on the currently displayed line series value.


<!--
Describe what is the purpose of this Pull Request:
- Does it resolve a bug?
- Does it implement a new feature?
- Does it improve something existing?

Be as elaborate as possible!
-->

#### Related Issues

#284 

### Design Decisions

#### Technical
The selection is saved in the user preference, and also with a district-compartment key, meaning that when user changes district and compartment, the y-axis limit will be different for each one.

Design question: should I make the setting globally for the whole line chart or different y-Axis scale for each scenario, compartment and district selection? (similar to thresholds)

#### UI/UX
The UI Text field is inside the line chart settings and user must click the y-axis menu settings to get into a menu with text field and change the value. 
ps: I'm not sure whether this has the best UX, another alternative approach is to just put the text field on the top menu, so user doesn't have to click it extra.

<!--
Please give a short explanation about why you implemented the PR as you did.
Discuss possible alternative implementations that you considered and why you chose this one.

If the PR is trivial you can remove this section.
-->

### Performance & Quality

<!--
Please attach exports from
- React Developer Tools Profiler run
- Performance insights page load measurement
If you have trouble creating them refer to the docs.
If the PR is trivial you may remove this section
-->

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [x] All texts have been internationalized with at least the following languages:
  - [x] English
  - [x] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [x] I added the changes to the next release section of the [changelog](../docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [x] I ran the software once and tried all new and related functionality to this PR
- [x] I looked at all new and changed lines of code and commented on possible problems
- [x] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [x] I checked the internationalized strings for spelling errors
- [x] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../docs/changelog/changelog-en.md)
