### PR TITLE
Fix filter action display on long filter names

### DIFF
--- a/docs/changelog/changelog-de.md
+++ b/docs/changelog/changelog-de.md
@@ -38,6 +38,8 @@ SPDX-License-Identifier: CC-BY-4.0
 - Ein Fehler wurde behoben, wo Daten angezeigt wurden, obwohl kein Szenario aufgedeckt war.
 - Die Gruppenfilter funktionieren wieder.
 - Die Menüpunkte Impressum, Datenschutzerklärung, Barrierefreiheit, Attribution und Versionshistorie sind wieder erreichbar ohne die Seite zum Absturz zu bringen.
+- Ein Anzeigeproblem bei langen Filternamen wurde behoben, bei dem die Aktionsschaltflächen bei sehr langen Filternamen nicht zugänglich waren.
+
 ---
 
 ## v0.3.1-beta

--- a/docs/changelog/changelog-en.md
+++ b/docs/changelog/changelog-en.md
@@ -38,6 +38,7 @@ SPDX-License-Identifier: CC-BY-4.0
 - A bug was fixed where data was shown while no scenario was active.
 - The group filters are working again.
 - The menu items Imprint, Privacy Policy, Accessibility, Attribution, and Changelog are available again without crashing the page.
+- Fixed a long filter name display issues where the action button is not accessible when using long filter names.
 
 ---
 

--- a/src/components/ScenarioComponents/FilterComponents/GroupFilterCard.tsx
+++ b/src/components/ScenarioComponents/FilterComponents/GroupFilterCard.tsx
@@ -80,18 +80,33 @@ export default function GroupFilterCard({
         onClick={() => {
           selectFilterCallback(selected ? null : item);
         }}
+        sx={{
+          flex: 1,
+          minWidth: 0,
+        }}
       >
-        <CardContent sx={{backgroundColor: selected ? theme.palette.info.main : theme.palette.background.paper}}>
+        <CardContent
+          sx={{
+            backgroundColor: selected ? theme.palette.info.main : theme.palette.background.paper,
+          }}
+        >
           <Typography
             variant='body1'
-            sx={{color: selected ? theme.palette.primary.contrastText : theme.palette.text.primary}}
+            sx={{
+              color: selected ? theme.palette.primary.contrastText : theme.palette.text.primary,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              maxWidth: '100%',
+            }}
+            title={item.name} // Show full name on hover
           >
             {item.name}
           </Typography>
         </CardContent>
       </CardActionArea>
       <Divider orientation='vertical' variant='middle' flexItem />
-      <CardActions>
+      <CardActions sx={{flexShrink: 0}}>
         <Checkbox
           checkedIcon={<Visibility />}
           icon={<VisibilityOffOutlined color='disabled' />}

--- a/src/components/ScenarioComponents/FilterComponents/ManageGroupDialog.tsx
+++ b/src/components/ScenarioComponents/FilterComponents/ManageGroupDialog.tsx
@@ -228,6 +228,7 @@ export default function ManageGroupDialog({
               flexDirection: 'column',
               justifyContent: 'center',
               alignItems: 'center',
+              padding: 4,
             }}
           >
             <Typography variant='body1'>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

Fix the filter action display by ensuring it's displayed on really long filter names.

#### Related Issues

#420 

### Performance & Quality

<!--
Please attach exports from
- React Developer Tools Profiler run
- Performance insights page load measurement
If you have trouble creating them refer to the docs.
If the PR is trivial you may remove this section
-->

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [x] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [x] I added the changes to the next release section of the [changelog](../docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../docs/changelog/changelog-en.md)
