### PR TITLE
 fix Parameter view group filters bug

### DIFF
--- a/src/components/ParameterEditor.tsx
+++ b/src/components/ParameterEditor.tsx
@@ -44,6 +44,11 @@ export default function ParameterEditor() {
         if (contextData?.parameterDefinitions) {
           const paramDefinition = contextData.parameterDefinitions[paramValues.parameterId];
 
+          // check, to prevent crash after creating a group filter and refreshing
+          if (!paramDefinition) {
+            return [];
+          }
+
           const data = paramValues.values.flatMap((group) => ({
             span: 1,
             min: group.valueMin,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 German Aerospace Center (DLR)
SPDX-License-Identifier: CC0-1.0
-->

### Description

Fixes the bug that happened when a group filter is created and page is refreshed, the parameter view will not load because of missing parameter name.

error:
Uncaught TypeError: can't access property "name", paramDefinition is undefined
    parameters ParameterEditor.tsx:66
    parameters ParameterEditor.tsx:43
    React 3
    ParameterEditor ParameterEditor.tsx:41
    React 13
ParameterEditor.tsx:66:44
    parameters ParameterEditor.tsx:66
    FlattenIntoArray self-hosted:674
    flatMap self-hosted:652
    parameters ParameterEditor.tsx:43
    React 3
    ParameterEditor ParameterEditor.tsx:41
    React 13

#### Related Issues

<!--
Add references to the issues addressed in this PR (#<issue number>)
-->

### Design Decisions

added conditionals if empty

### Performance & Quality

<!--
Please attach exports from
- React Developer Tools Profiler run
- Performance insights page load measurement
If you have trouble creating them refer to the docs.
If the PR is trivial you may remove this section
-->

### Checklist

**I, the author of this PR checked the following requirements for good software quality:**

- [x] The code is properly formatted (I ran the formatter)
- [x] The code is written with our software quality standards (I ran the linter)
- [x] The code is written using our code style
- [ ] Extensive in source documentation has been added
- [ ] Unit and/or integration tests have been added
- [ ] All texts have been internationalized with at least the following languages:
  - [ ] English
  - [ ] German
- [ ] I tried addressing all new accessibility problems displayed in the console and documented if they can't be fixed
- [ ] I attached performance measurements to prevent performance degradation
- [ ] I added the changes to the next release section of the [changelog](../docs/changelog/changelog-en.md)

**I, the reviewer checked the following things:**

- [ ] I ran the software once and tried all new and related functionality to this PR
- [ ] I looked at all new and changed lines of code and commented on possible problems
- [ ] I read the added documentation and checked if it is understandable and clear
- [ ] I checked the added tests for completeness
- [ ] I checked the internationalized strings for spelling errors
- [ ] I checked the performance metrics for problems or unexplained degradation
- [ ] I checked that the changes are noted in the [changelog](../docs/changelog/changelog-en.md)
